### PR TITLE
Fix to Dot Vector Solution (P10) for odd array sizes 

### DIFF
--- a/solutions/p10/p10.mojo
+++ b/solutions/p10/p10.mojo
@@ -51,7 +51,7 @@ fn dot_product(
 
     # only thread 0 writes the final result
     if local_i == 0:
-        out[0] = shared[0]
+        out[0] = shared[0] if size % 2 == 0 else shared[0] + shared[size - 1]
 
 
 # ANCHOR_END: dot_product_solution

--- a/solutions/p10/p10_layout_tensor.mojo
+++ b/solutions/p10/p10_layout_tensor.mojo
@@ -44,7 +44,7 @@ fn dot_product[
 
     # Only thread 0 writes the final result
     if local_i == 0:
-        out[0] = shared[0]
+        out[0] = shared[0] if size % 2 == 0 else shared[0] + shared[size - 1]
 
 
 # ANCHOR_END: dot_product_layout_tensor_solution


### PR DESCRIPTION
I was looking at the solutions for Puzzle 10 and noticed that the provided solution is missing the parallel reduction of the last element if the array size is odd-numbered.  
Feel free to reject if not relevant since puzzle inputs are even.