### PR TITLE
Remove all tab links from Puzzles header - Please do not merge until Docs & MAX Builds release

### DIFF
--- a/book/theme/index.hbs
+++ b/book/theme/index.hbs
@@ -147,15 +147,6 @@
                             <li role="none"><button role="menuitem" class="theme" id="ayu">Dark</button></li>
                         </ul>
                     </div>
-                <div class="menu-links">
-                    <li><a href="https://docs.modular.com/max/get-started/" target="_blank"><div>Product</div></a></li>
-                    <li><a href="https://www.modular.com/max/solutions/agent" target="_blank">Solutions</a></li>
-                    <li><a href="https://builds.modular.com/?category=featured" target="_blank">Resources</a></li>
-                    <li><a href="https://www.modular.com/company/about" target="_blank">Company</a></li>
-                    <li><a href="https://www.modular.com/pricing" target="_blank">Pricing</a></li>
-                    <li><a href="https://docs.modular.com" target="_blank">Docs</a></li>
-                    <li><a href="https://www.modular.com/blog" target="_blank">Blog</a></li>
-                </div>
                 <div class="right-buttons">
                     {{#if search_enabled}}
                     <button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">


### PR DESCRIPTION
### Relevant Issue
https://linear.app/modularml/issue/DESN-742/remove-marketing-links-from-puzzles-top-nav

### Note
The release of this change should sync with Docs and MAX Builds' release of the new navigation. 