### PR TITLE
Fix index usage in tensor addition for consistency across implementations on Puzzle 05 Broadcast

### DIFF
--- a/problems/p05/p05.mojo
+++ b/problems/p05/p05.mojo
@@ -37,7 +37,7 @@ def main():
 
             for i in range(SIZE):
                 for j in range(SIZE):
-                    expected[i * SIZE + j] = a_host[i] + b_host[j]
+                    expected[i * SIZE + j] = a_host[j] + b_host[i]
 
         ctx.enqueue_function[broadcast_add](
             out.unsafe_ptr(),

--- a/problems/p05/p05_layout_tensor.mojo
+++ b/problems/p05/p05_layout_tensor.mojo
@@ -53,7 +53,7 @@ def main():
 
             for i in range(SIZE):
                 for j in range(SIZE):
-                    expected_tensor[i, j] = a_host[i] + b_host[j]
+                    expected_tensor[i, j] = a_host[j] + b_host[i]
 
         a_tensor = LayoutTensor[dtype, a_layout](a.unsafe_ptr())
         b_tensor = LayoutTensor[dtype, b_layout](b.unsafe_ptr())

--- a/solutions/p05/p05_layout_tensor.mojo
+++ b/solutions/p05/p05_layout_tensor.mojo
@@ -56,7 +56,7 @@ def main():
 
             for i in range(SIZE):
                 for j in range(SIZE):
-                    expected_tensor[i, j] = a_host[i] + b_host[j]
+                    expected_tensor[i, j] = a_host[j] + b_host[i]
 
         a_tensor = LayoutTensor[dtype, a_layout](a.unsafe_ptr())
         b_tensor = LayoutTensor[dtype, b_layout](b.unsafe_ptr())


### PR DESCRIPTION
This pull request fixes a logic error in the computation of the `expected` and `expected_tensor` arrays in several files. The changes ensure the correct indexing of `a_host` and `b_host` during nested loop operations.

### Fixes to indexing logic:

* [`problems/p05/p05.mojo`](diffhunk://#diff-85c70d19c1a6f82b755d0ebfd781ccd8bc9e3cbc29daef3c91a85a4251ca6fc9L40-R40): Corrected the indexing logic in the `expected` array computation by swapping the roles of `i` and `j` for `a_host` and `b_host`. 
* [`problems/p05/p05_layout_tensor.mojo`](diffhunk://#diff-5a3882914e3d5be43d561200559e62f5dd9372a8392a1afdd1fa30c8d3dae3bfL56-R56): Corrected the indexing logic in the `expected_tensor` array computation by swapping the roles of `i` and `j` for `a_host` and `b_host`. 
* [`solutions/p05/p05_layout_tensor.mojo`](diffhunk://#diff-41f78304fbf078e87f1235dd825b8c1b03e2fb5ef9787530c2eaf4ea215e6d2fL59-R59): Fixed the same indexing issue in the `expected_tensor` array computation in the solutions file.