### PR TITLE
Remove unnecessary nested loop and condition check

### DIFF
--- a/problems/p11/p11.mojo
+++ b/problems/p11/p11.mojo
@@ -127,6 +127,4 @@ def main():
             print("out:", out_host)
             print("expected:", expected)
             for i in range(size):
-                for j in range(conv):
-                    if i + j < size:
-                        assert_equal(out_host[i], expected[i])
+                assert_equal(out_host[i], expected[i])

--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -190,6 +190,4 @@ def main():
             print("out:", out_host)
             print("expected:", expected)
             for i in range(size):
-                for j in range(conv):
-                    if i + j < size:
-                        assert_equal(out_host[i], expected[i])
+                assert_equal(out_host[i], expected[i])


### PR DESCRIPTION
## Summary

Simplified the assertion logic by removing redundant `for j in range(conv)` loop and `if i + j < size` condition check.

## Changes

- Removed unused variable j and its associated for loop
- Eliminated unnecessary size comparison condition
- Streamlined the assertion to directly compare `out_host[i]` with `expected[i]`

## Rationale
- The previous code contained a meaningless nested loop structure where:
  - Variable j was declared in the for loop but never actually used in the assertion
  - The condition `if i + j < size` was unnecessary since the outer loop already ensures proper bounds
  - The assertion `assert_equal(out_host[i], expected[i])` doesn't depend on j at all