### PR TITLE
Remove unused parameter in puzzle 12

### DIFF
--- a/problems/p12/p12.mojo
+++ b/problems/p12/p12.mojo
@@ -44,7 +44,6 @@ fn prefix_sum_local_phase[
     output: LayoutTensor[mut=False, dtype, out_layout],
     a: LayoutTensor[mut=False, dtype, in_layout],
     size: Int,
-    num_blocks: Int,
 ):
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
@@ -106,7 +105,6 @@ def main():
                 out_tensor,
                 a_tensor,
                 size,
-                num_blocks,
                 grid_dim=BLOCKS_PER_GRID_2,
                 block_dim=THREADS_PER_BLOCK_2,
             )

--- a/solutions/p12/p12.mojo
+++ b/solutions/p12/p12.mojo
@@ -185,7 +185,6 @@ def main():
                 out_tensor,
                 a_tensor,
                 size,
-                num_blocks,
                 grid_dim=BLOCKS_PER_GRID_2,
                 block_dim=THREADS_PER_BLOCK_2,
             )


### PR DESCRIPTION
## Summary
Cleaned up function signature by removing the unused `num_blocks` parameter.

## Changes
- Removed `num_blocks`: Int parameter from function definition
- Removed corresponding `num_blocks` argument from function call

## Rationale
- The previous code included an unnecessary parameter where:
  - `num_blocks` parameter was defined in the function signature but never used within the function body
  - The parameter was being passed during function calls but served no purpose