### PR TITLE
Fix `dtype` attribute access and remove redundant specifications in puzzle 15

### DIFF
--- a/problems/p15/op/conv1d.mojo
+++ b/problems/p15/op/conv1d.mojo
@@ -73,8 +73,8 @@ struct Conv1DCustomOp:
         dtype: DType = DType.float32,
     ](
         output: OutputTensor[rank=1],
-        input: InputTensor[dtype = output.dtype, rank = output.rank],
-        kernel: InputTensor[dtype = output.dtype, rank = output.rank],
+        input: InputTensor[rank = output.rank],
+        kernel: InputTensor[rank = output.rank],
         # the context is needed for some GPU calls
         ctx: DeviceContextPtr,
     ) raises:
@@ -90,9 +90,9 @@ struct Conv1DCustomOp:
             gpu_ctx = ctx.get_device_context()
             # making sure the output tensor is zeroed out before the kernel is called
             gpu_ctx.enqueue_memset(
-                DeviceBuffer[output.dtype](
+                DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](
+                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
                         output_tensor.ptr
                     ),
                     input_size,

--- a/problems/p15/p15.py
+++ b/problems/p15/p15.py
@@ -47,6 +47,7 @@ def conv_1d(
         # Note: the name must match the name used in `@compiler.register("conv1d")` in op/conv1d.mojo
         output = ops.custom(
             name="conv1d",
+            device=DeviceRef.from_device(device),
             values=[input_value, kernel_value],
             out_types=[
                 TensorType(

--- a/solutions/p15/op/conv1d.mojo
+++ b/solutions/p15/op/conv1d.mojo
@@ -91,9 +91,9 @@ struct Conv1DCustomOp:
             gpu_ctx = ctx.get_device_context()
             # making sure the output tensor is zeroed out before the kernel is called
             # gpu_ctx.enqueue_memset(
-            #     DeviceBuffer[output.type](
+            #     DeviceBuffer[output_tensor.type](
             #         gpu_ctx,
-            #         rebind[UnsafePointer[Scalar[output.type]]](output_tensor.ptr),
+            #         rebind[UnsafePointer[Scalar[output_tensor.type]]](output_tensor.ptr),
             #         input_size,
             #         owning=False,
             #     ),


### PR DESCRIPTION
## Summary

Fixed compilation error by correcting `dtype` attribute access and simplified tensor type declarations by removing redundant `dtype` specifications.

## Changes
- Removed redundant `dtype = output.dtype` specifications from input and kernel tensor declarations
- Changed `output.dtype` to `output_tensor.dtype` in `DeviceBuffer` and `rebind` calls
- Simplified `InputTensor` declarations to only specify rank parameter
- Added missing `device` parameter to `ops.custom` function call

Rationale
- `output.dtype` was not accessible on `ManagedTensorSlice[IOSpec(), static_spec=static_spec]` type
- Redundant `dtype` specifications in tensor declarations were unnecessary since `rank` is sufficient
- The `output_tensor.dtype` provides the correct `dtype` access for buffer operations
- Missing device parameter was causing execution context issues
