### PR TITLE
Fix softmax custom operation execution and add device target specification in puzzle 16

### DIFF
--- a/book/src/puzzle_16/puzzle_16.md
+++ b/book/src/puzzle_16/puzzle_16.md
@@ -464,6 +464,7 @@ The Python integration creates a seamless bridge between NumPy arrays and our op
            )
        ],
        parameters={
+           "target": "gpu" if device == Accelerator() else "cpu",
            "input_size": input_tensor.shape[0],
            "dtype": dtype,
        },
@@ -473,7 +474,7 @@ The Python integration creates a seamless bridge between NumPy arrays and our op
    - Name matching the `@compiler.register("softmax")` in our Mojo code
    - Input values passed as a list
    - Output type definition matching the input shape and type
-   - Parameters required by our kernel, including the vector size and data type
+   - Parameters required by our kernel, including the target device, vector size and data type
    - We extract the tensor from the first returned element with `[0].tensor`
 
 3. **Graph Output Definition**:

--- a/problems/p16/op/softmax.mojo
+++ b/problems/p16/op/softmax.mojo
@@ -14,7 +14,6 @@ alias TPB = 128
 alias BLOCKS_PER_GRID = (1, 1)
 alias THREADS_PER_BLOCK = (TPB, 1)
 alias layout = Layout.row_major(SIZE)
-alias dtype = DType.float32
 
 
 fn softmax_gpu_kernel[
@@ -60,8 +59,8 @@ struct SoftmaxCustomOp:
         input_size: Int,
         dtype: DType = DType.float32,
     ](
-        output: OutputTensor[dtype=dtype, rank=1],
-        input: InputTensor[dtype = output.dtype, rank = output.rank],
+        output: OutputTensor[rank=1],
+        input: InputTensor[rank = output.rank],
         ctx: DeviceContextPtr,
     ) raises:
         # Note: rebind is necessary now but it shouldn't be!
@@ -78,9 +77,9 @@ struct SoftmaxCustomOp:
             gpu_ctx = ctx.get_device_context()
             # making sure the output tensor is zeroed out before the kernel is called
             gpu_ctx.enqueue_memset(
-                DeviceBuffer[output.dtype](
+                DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](
+                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
                         output_tensor.ptr
                     ),
                     input_size,

--- a/solutions/p16/op/softmax.mojo
+++ b/solutions/p16/op/softmax.mojo
@@ -138,9 +138,9 @@ struct SoftmaxCustomOp:
             gpu_ctx = ctx.get_device_context()
             # making sure the output tensor is zeroed out before the kernel is called
             # gpu_ctx.enqueue_memset(
-            #     DeviceBuffer[output.type](
+            #     DeviceBuffer[output_tensor.type](
             #         gpu_ctx,
-            #         rebind[UnsafePointer[Scalar[output.type]]](out_tensor.ptr),
+            #         rebind[UnsafePointer[Scalar[output_tensor.type]]](out_tensor.ptr),
             #         input_size,
             #         owning=False,
             #     ),

--- a/solutions/p16/p16.py
+++ b/solutions/p16/p16.py
@@ -45,6 +45,7 @@ def softmax(
                 )
             ],
             parameters={
+                "target": "gpu" if device == Accelerator() else "cpu",
                 "input_size": input_tensor.shape[0],
                 "dtype": dtype,
             },


### PR DESCRIPTION
## Summary
Resolved custom operation execution issues by fixing dtype attribute access, removing conflicting alias, and adding explicit device target parameters for proper CPU/GPU execution differentiation.

## Changes
- Removed conflicting dtype alias in `problems/p16/op/softmax.mojo` that was preventing proper custom op execution
- Fixed `dtype` attribute access by changing `output.dtype` to `output_tensor.dtype` in buffer operations
- Added `"target": "gpu"/"cpu"` parameter specification based on device type in Python integration files
- Simplified tensor declarations by removing redundant dtype specifications
- Updated documentation to reflect target device parameter requirements

## Rationale
- The `alias dtype = DType.float32` was creating namespace conflicts with the actual tensor dtype access, causing the custom operation registration and execution to fail
- Removing this alias allows proper dtype resolution from the actual tensor objects
- Target device specification is for explicit target device

## Question

@ehsanmok I notice that in the `solutions/p16/op/softmax.mojo`, `gpu_ctx.enqueue_memset` is commented out. What is the reason for this? While my understanding of this part is limited, I believe that uncommenting this code for initialization would be the right approach. Could you clarify why this initialization step is being skipped and whether enabling it would be more appropriate for ensuring correct execution?