### PR TITLE
[Fix] uncomment back gpu memory reset process

### DIFF
--- a/solutions/p15/op/conv1d.mojo
+++ b/solutions/p15/op/conv1d.mojo
@@ -90,15 +90,17 @@ struct Conv1DCustomOp:
         if target == "gpu":
             gpu_ctx = ctx.get_device_context()
             # making sure the output tensor is zeroed out before the kernel is called
-            # gpu_ctx.enqueue_memset(
-            #     DeviceBuffer[output_tensor.type](
-            #         gpu_ctx,
-            #         rebind[UnsafePointer[Scalar[output_tensor.type]]](output_tensor.ptr),
-            #         input_size,
-            #         owning=False,
-            #     ),
-            #     0,
-            # )
+            gpu_ctx.enqueue_memset(
+                DeviceBuffer[output_tensor.dtype](
+                    gpu_ctx,
+                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
+                        output_tensor.ptr
+                    ),
+                    input_size,
+                    owning=False,
+                ),
+                0,
+            )
             # ANCHOR: conv1d_custom_op_solution
             gpu_ctx.enqueue_function[
                 conv1d_kernel[

--- a/solutions/p16/op/softmax.mojo
+++ b/solutions/p16/op/softmax.mojo
@@ -137,15 +137,17 @@ struct SoftmaxCustomOp:
         if target == "gpu":
             gpu_ctx = ctx.get_device_context()
             # making sure the output tensor is zeroed out before the kernel is called
-            # gpu_ctx.enqueue_memset(
-            #     DeviceBuffer[output_tensor.type](
-            #         gpu_ctx,
-            #         rebind[UnsafePointer[Scalar[output_tensor.type]]](out_tensor.ptr),
-            #         input_size,
-            #         owning=False,
-            #     ),
-            #     0,
-            # )
+            gpu_ctx.enqueue_memset(
+                DeviceBuffer[output_tensor.dtype](
+                    gpu_ctx,
+                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
+                        output_tensor.ptr
+                    ),
+                    input_size,
+                    owning=False,
+                ),
+                0,
+            )
 
             gpu_ctx.enqueue_function[
                 softmax_gpu_kernel[layout, input_size, dtype]


### PR DESCRIPTION
## Summary
Uncomment out debugging processes in `solutions/p15/op/conv1d.mojo` and `solutions/p16/op/softmax.mojo`

## Changes
- Uncommented back to run memory reset as 0
- Fix type from `output_tensor.type` to `output_tensor.dtype`

## Rationale
- Discuss at https://github.com/modular/mojo-gpu-puzzles/pull/40#issuecomment-2997375432