### PR TITLE
Fix softmax custom operation execution and add device target specification in puzzle 17

### DIFF
--- a/problems/p17/op/attention.mojo
+++ b/problems/p17/op/attention.mojo
@@ -88,7 +88,7 @@ fn transpose_kernel[
 
 
 # Apply softmax to attention scores taken from p16
-fn softmax_kernel[
+fn softmax_gpu_kernel[
     layout: Layout,
     seq_len: Int,
     dtype: DType = DType.float32,
@@ -206,10 +206,10 @@ struct AttentionCustomOp:
         d: Int,
         dtype: DType = DType.float32,
     ](
-        output: OutputTensor[dtype=dtype, rank=1],  # Output vector (d,)
-        q: InputTensor[dtype=dtype, rank=1],  # Query vector (d,)
-        k: InputTensor[dtype=dtype, rank=2],  # Key matrix (seq_len, d)
-        v: InputTensor[dtype=dtype, rank=2],  # Value matrix (seq_len, d)
+        output: OutputTensor[rank=1],  # Output vector (d,)
+        q: InputTensor[rank=1],  # Query vector (d,)
+        k: InputTensor[rank=2],  # Key matrix (seq_len, d)
+        v: InputTensor[rank=2],  # Value matrix (seq_len, d)
         ctx: DeviceContextPtr,
     ) raises:
         # Define layouts

--- a/problems/p17/p17.py
+++ b/problems/p17/p17.py
@@ -66,6 +66,7 @@ def attention(
         output = ops.custom(
             name="attention",
             values=[q_value, k_value, v_value],
+            device=DeviceRef.from_device(device),
             out_types=[
                 TensorType(
                     dtype=dtype,


### PR DESCRIPTION
## Summary
Resolved custom operation execution issues by fixing `dtype` attribute access, and adding explicit device target parameters for proper CPU/GPU execution differentiation.

## Changes
- Removed `dtype` parameters  that was preventing proper custom op execution
- Added a device parameter specification based
- Rename a function from `softmax_kernel` to `softmax_gpu_kernel` as like `solutions/p17/op/attention.mojo`

## Rationale
- Almost same as:
  - #39
  - #40 

## Comments
- I'm not sure that it is proper work to fix function's name. I just want to fit as same as the solution.