### PR TITLE
Puzzle 10: Update shared mem out-of-bounds check and fix type in THREADS_PER_BLOCK

### DIFF
--- a/problems/p10/p10.mojo
+++ b/problems/p10/p10.mojo
@@ -9,7 +9,7 @@ from testing import assert_equal
 alias TPB = 8
 alias SIZE = 8
 alias BLOCKS_PER_GRID = (1, 1)
-alias THREADS_PER_BLOCK = (SIZE, 1)
+alias THREADS_PER_BLOCK = (TPB, 1)
 alias dtype = DType.float32
 
 

--- a/problems/p10/p10_layout_tensor.mojo
+++ b/problems/p10/p10_layout_tensor.mojo
@@ -10,7 +10,7 @@ from layout.tensor_builder import LayoutTensorBuild as tb
 alias TPB = 8
 alias SIZE = 8
 alias BLOCKS_PER_GRID = (1, 1)
-alias THREADS_PER_BLOCK = (SIZE, 1)
+alias THREADS_PER_BLOCK = (TPB, 1)
 alias dtype = DType.float32
 alias layout = Layout.row_major(SIZE)
 alias out_layout = Layout.row_major(1)

--- a/solutions/p10/p10.mojo
+++ b/solutions/p10/p10.mojo
@@ -8,7 +8,7 @@ from testing import assert_equal
 alias TPB = 8
 alias SIZE = 8
 alias BLOCKS_PER_GRID = (1, 1)
-alias THREADS_PER_BLOCK = (SIZE, 1)
+alias THREADS_PER_BLOCK = (TPB, 1)
 alias dtype = DType.float32
 
 

--- a/solutions/p10/p10_layout_tensor.mojo
+++ b/solutions/p10/p10_layout_tensor.mojo
@@ -7,7 +7,7 @@ from testing import assert_equal
 alias TPB = 8
 alias SIZE = 8
 alias BLOCKS_PER_GRID = (1, 1)
-alias THREADS_PER_BLOCK = (SIZE, 1)
+alias THREADS_PER_BLOCK = (TPB, 1)
 alias dtype = DType.float32
 alias layout = Layout.row_major(SIZE)
 alias out_layout = Layout.row_major(1)


### PR DESCRIPTION
In this puzzle the check 
```
if global_i < size:
    shared[local_i] = a[global_i] * b[global_i]
```
is unecessary because `TPB == Size == 8` (`global_i` cannot be greater than `size - 1`). If however `TPB >= size` (the condition we are guarding against) this check alone would not be sufficient because the values of `shared[local_i], global_i>= size` which would be used in the reduction are undefined, that is unless shared memory is guaranteed to be initialized to `0` in mojo.

Also fixed typo. `THREADS_PER_BLOCK` was using the `SIZE` instead of `TPB`.