### PR TITLE
Fix out of bounds write in p11

### DIFF
--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -30,8 +30,6 @@ fn conv_1d_simple[
     shared_b = tb[dtype]().row_major[CONV]().shared().alloc()
     if global_i < SIZE:
         shared_a[local_i] = a[global_i]
-    else:
-        shared_a[local_i] = 0
 
     if global_i < CONV:
         shared_b[local_i] = b[global_i]


### PR DESCRIPTION
The `shared_a` tensor has length SIZE, we should not attempt to write out of bounds.