### PR TITLE
[Puzzle 16] Remove redundant shared memory initialization with fill()

### DIFF
--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -151,8 +151,8 @@ fn matmul_idiomatic_tiled[
 
     # Get the tile of the output matrix that this thread block is responsible for
     out_tile = output.tile[TPB, TPB](block_idx.y, block_idx.x)
-    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc().fill(0)
-    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc().fill(0)
+    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
+    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
 
     var acc: output.element_type = 0
 


### PR DESCRIPTION
The initialization of `a_shared` and `b_shared` with `fill()` is unecessary and removed in this PR.

Additionally the current implementation of [`LayoutTensor.fill()`](https://docs.modular.com/mojo/kernels/layout/layout_tensor/LayoutTensor/#fill) is unsuitable for use with shared memory because each thread redundantly initializes each element of shared memory in a loop.