### PR TITLE
[Puzzle 18&19] Use consistent version of Softmax

### DIFF
--- a/book/src/puzzle_19/puzzle_19.md
+++ b/book/src/puzzle_19/puzzle_19.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-In this puzzle, we'll implement the attention mechanism as a custom MAX Graph operation. Attention is a fundamental building block of modern neural networks, poplularized particularly [transformers](https://arxiv.org/abs/1706.03762), that allows models to focus on relevant parts of the input when making predictions.
+In this puzzle, we'll implement the attention mechanism as a custom MAX Graph operation. Attention is a fundamental building block of modern neural networks, popularized particularly [transformers](https://arxiv.org/abs/1706.03762), that allows models to focus on relevant parts of the input when making predictions.
 
 Mathematically, the attention function is defined as:
 
 $$\\Large \\text{Attention}(Q, K, V) = \\text{softmax}(Q \\cdot K^T) \\cdot V$$
 
 Where:
-- \\(Q\\) is the **query vector** of shape \\((d,)\\) - represents what we're looking for
-- \\(K\\) is the **key matrix** of shape \\((\text{seq\_len}, d)\\) - represents what's available to match against
-- \\(V\\) is the **value matrix** of shape \\((\text{seq\_len}, d)\\) - represents the information to retrieve
+- \\(Q\\) is the **query vector** of shape \\((d,)~\\) - represents what we're looking for
+- \\(K\\) is the **key matrix** of shape \\((\text{seq\_len}, d)~\\) - represents what's available to match against
+- \\(V\\) is the **value matrix** of shape \\((\text{seq\_len}, d)~\\) - represents the information to retrieve
 - The output is a **weighted combination** vector of shape \\((d,)\\)
 
 The computation involves three main steps:
@@ -70,9 +70,9 @@ Our GPU implementation **reuses and combines optimized kernels from previous puz
 
 ## Configuration
 
-- **Sequence length**: \\(\text{SEQ\_LEN} = 16\\) - number of key/value vectors in our sequence
-- **Model dimension**: \\(\text{D} = 16\\) - dimensionality of each vector (query, keys, values)
-- **Threads per block**: \\(\text{TPB} = 16\\) - matches SEQ_LEN for optimal softmax performance
+- **Sequence length**: \\(\text{SEQ\_LEN} = 16~\\) - number of key/value vectors in our sequence
+- **Model dimension**: \\(\text{D} = 16~\\) - dimensionality of each vector (query, keys, values)
+- **Threads per block**: Individually optimized for each kernel
 - **Grid dimensions**: Computed dynamically to handle different matrix sizes efficiently
 - **Shared memory**: Utilized in transpose, matmul, and softmax kernels for performance
 
@@ -272,9 +272,9 @@ The attention operation follows the canonical mathematical definition:
 $$\\Large \\text{Attention}(Q, K, V) = \\text{softmax}(Q \\cdot K^T) \\cdot V$$
 
 **Breaking down the math**:
-- \\(Q \cdot K^T\\): Query-key similarity scores of shape: \\((1, \text{seq\_len})\\)
-- \\(\text{softmax}(\cdot)\\): Normalize scores to probabilities of shape: \\((1, \text{seq\_len})\\)
-- \\(\text{weights} \cdot V\\): Weighted combination of values of shape: \\((1, d)\\)
+- \\(Q \cdot K^T~\\): Query-key similarity scores of shape: \\((1, \text{seq\_len})\\)
+- \\(\text{softmax}(\cdot)~\\): Normalize scores to probabilities of shape: \\((1, \text{seq\_len})\\)
+- \\(\text{weights} \cdot V~\\): Weighted combination of values of shape: \\((1, d)\\)
 
 This involves several computational steps that we optimize using GPU kernels from previous puzzles.
 
@@ -320,7 +320,7 @@ weights = scores_2d.reshape[layout_scores]()
 
 The implementation achieves **maximum memory efficiency** through:
 - **Zero-copy reshaping**: Reinterpreting tensor shapes without moving data in memory
-- **Intelligent buffer reuse**: The same `scores_weights_buf` serves dual purposes as both scores \\((1,\\text{seq\\_len})\\) and weights \\((\\text{seq\\_len},)\\)
+- **Intelligent buffer reuse**: The same `scores_weights_buf` serves dual purposes as both scores \\((1,\\text{seq_len})\\) and weights \\((\\text{seq_len},)\\)
 - **Minimal allocations**: Only 2 temporary buffers power the entire attention operation
 - **Memory coalescing**: All operations maintain optimal memory access patterns
 

--- a/problems/p18/p18.py
+++ b/problems/p18/p18.py
@@ -44,7 +44,7 @@ def softmax(
 
 
 if __name__ == "__main__":
-    INPUT_SIZE = 128
+    INPUT_SIZE = 128 # This must be equal to SIZE in softmax.mojo
     cpu_session = InferenceSession(devices=[CPU()])
     gpu_session = InferenceSession(devices=[Accelerator()])
     input_array = np.random.randn(INPUT_SIZE).astype(np.float32)

--- a/problems/p18/test/test_softmax.mojo
+++ b/problems/p18/test/test_softmax.mojo
@@ -2,14 +2,14 @@ from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
 from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_almost_equal
+from bit import log2_ceil
 
 from op import softmax_gpu_kernel, softmax_cpu_kernel
 
 alias SIZE = 128
-alias TPB = 128
-alias BLOCKS_PER_GRID = (1, 1)
-alias THREADS_PER_BLOCK = (TPB, 1)
 alias layout = Layout.row_major(SIZE)
+alias GRID_DIM_X = 1
+alias BLOCK_DIM_X = 1 << log2_ceil(SIZE)
 alias dtype = DType.float32
 
 
@@ -51,8 +51,8 @@ def test_softmax():
         ctx.enqueue_function[softmax_gpu_kernel[layout, SIZE, dtype]](
             output_tensor,
             input_tensor,
-            grid_dim=BLOCKS_PER_GRID,
-            block_dim=THREADS_PER_BLOCK,
+            grid_dim=GRID_DIM_X,
+            block_dim=BLOCK_DIM_X,
         )
 
         ctx.synchronize()

--- a/problems/p19/op/attention.mojo
+++ b/problems/p19/op/attention.mojo
@@ -4,6 +4,7 @@ from gpu.host import DeviceContext, HostBuffer, DeviceBuffer
 from layout import Layout, LayoutTensor
 from layout.tensor_builder import LayoutTensorBuild as tb
 from math import exp
+from bit import log2_ceil
 from utils.numerics import max_finite, min_finite
 import compiler
 from runtime.asyncrt import DeviceContextPtr
@@ -11,10 +12,10 @@ from tensor import InputTensor, OutputTensor
 from gpu.memory import async_copy_wait_all
 from layout.layout_tensor import copy_dram_to_sram_async
 
-alias SEQ_LEN = 16
-alias D = 16
-alias TPB = SEQ_LEN
-
+alias SEQ_LEN = 16 # This must be equal to SEQ_LEN in p19.py
+alias D = 16 # This must be equal to D in p19.py
+alias SOFTMAX_BLOCK_DIM_X = 1 << log2_ceil(SEQ_LEN)
+alias TPB = 16
 
 # Tiled matrix multiplication from p14 - adapted for attention
 fn matmul_idiomatic_tiled[
@@ -90,60 +91,60 @@ fn transpose_kernel[
 # Apply softmax to attention scores taken from p16
 fn softmax_gpu_kernel[
     layout: Layout,
-    seq_len: Int,
+    input_size: Int,
     dtype: DType = DType.float32,
 ](
-    output: LayoutTensor[mut=True, dtype, layout, MutableAnyOrigin],
-    scores: LayoutTensor[mut=False, dtype, layout, MutableAnyOrigin],
+    output: LayoutTensor[mut=True, dtype, layout],
+    input: LayoutTensor[mut=False, dtype, layout],
 ):
-    """Apply softmax to attention scores - exact p16 pattern."""
-    shared_max = tb[dtype]().row_major[TPB]().shared().alloc()
-    shared_sum = tb[dtype]().row_major[TPB]().shared().alloc()
-    global_i = block_dim.x * block_idx.x + thread_idx.x
-    local_i = thread_idx.x
+    shared_max = tb[dtype]().row_major[SOFTMAX_BLOCK_DIM_X]().shared().alloc()
+    shared_sum = tb[dtype]().row_major[SOFTMAX_BLOCK_DIM_X]().shared().alloc()
+    global_i = thread_idx.x
 
-    var thread_max: Scalar[dtype] = min_finite[dtype]()
-    if global_i < seq_len:
-        thread_max = rebind[Scalar[dtype]](scores[global_i])
+    # Initialize out-of-bounds (shared_max[local_i], global_i >= input_size) shared memory addresses to the minimum
+    # finite value for dtype, ensuring that if these elements are accessed in the parallel max reduction below they
+    # do not influence the result (max(min_finite, x) == x for any x).
+    var val: Scalar[dtype] = min_finite[dtype]()
+    if global_i < input_size:
+        val = rebind[Scalar[dtype]](input[global_i])
+    shared_max[global_i] = val
 
-    shared_max[local_i] = thread_max
     barrier()
 
-    # Parallel reduction to find max
-    stride = TPB // 2
+    # Parallel reduction to find max similar to reduction we saw before
+    stride = SOFTMAX_BLOCK_DIM_X // 2
     while stride > 0:
-        if local_i < stride:
-            shared_max[local_i] = max(
-                shared_max[local_i], shared_max[local_i + stride]
+        if global_i < stride:
+            shared_max[global_i] = max(
+                shared_max[global_i], shared_max[global_i + stride]
             )
         barrier()
         stride = stride // 2
 
     block_max = shared_max[0]
 
+    # Initialize out-of-bounds (shared_max[global_i], global_i >= input_size) shared memory addresses to 0.0,
+    # ensuring that if these elements are accessed in the parallel sum reduction below they
+    # do not influence the result (adding 0.0 does not change the sum).
     var exp_val: Scalar[dtype] = 0.0
-    if global_i < seq_len:
-        exp_val = rebind[Scalar[dtype]](exp(scores[global_i] - block_max))
-        output[global_i] = exp_val
-
-    shared_sum[local_i] = exp_val
+    if global_i < input_size:
+        exp_val = rebind[Scalar[dtype]](exp(val - block_max))
+    shared_sum[global_i] = exp_val
     barrier()
 
-    # Parallel reduction for sum
-    stride = TPB // 2
+    # Parallel reduction for sum similar to reduction we saw before
+    stride = SOFTMAX_BLOCK_DIM_X // 2
     while stride > 0:
-        if local_i < stride:
-            shared_sum[local_i] = (
-                shared_sum[local_i] + shared_sum[local_i + stride]
-            )
+        if global_i < stride:
+            shared_sum[global_i] += shared_sum[global_i + stride]
         barrier()
         stride = stride // 2
 
     block_sum = shared_sum[0]
 
     # Normalize by sum
-    if global_i < seq_len:
-        output[global_i] = output[global_i] / block_sum
+    if global_i < input_size:
+        output[global_i] = exp_val / block_sum
 
 
 # CPU implementation for vector attention
@@ -254,6 +255,8 @@ struct AttentionCustomOp:
                 (seq_len + TPB - 1) // TPB,
                 (1 + TPB - 1) // TPB,
             )
+            alias softmax_threads = SOFTMAX_BLOCK_DIM_X
+            alias softmax_blocks_per_grid = 1
             alias result_blocks_per_grid = (
                 (d + TPB - 1) // TPB,
                 (1 + TPB - 1) // TPB,

--- a/problems/p19/p19.py
+++ b/problems/p19/p19.py
@@ -192,8 +192,8 @@ def test_individual_operations():
 
 
 if __name__ == "__main__":
-    SEQ_LEN = 16  # Number of key/value vectors
-    D = 16  # Dimension of each vector
+    SEQ_LEN = 16  # Number of key/value vectors, must be equal to SEQ_LEN in attention.mojo
+    D = 16  # Dimension of each vector, must be equal to D in attention.mojo
 
     cpu_session = InferenceSession(devices=[CPU()])
     gpu_session = InferenceSession(devices=[Accelerator()])

--- a/solutions/p18/p18.py
+++ b/solutions/p18/p18.py
@@ -64,7 +64,7 @@ def softmax(
 
 
 if __name__ == "__main__":
-    INPUT_SIZE = 128
+    INPUT_SIZE = 128 # This must be equal to SIZE in softmax.mojo
     cpu_session = InferenceSession(devices=[CPU()])
     gpu_session = InferenceSession(devices=[Accelerator()])
     input_array = np.random.randn(INPUT_SIZE).astype(np.float32)

--- a/solutions/p18/test/test_softmax.mojo
+++ b/solutions/p18/test/test_softmax.mojo
@@ -2,14 +2,14 @@ from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
 from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_almost_equal
+from bit import log2_ceil
 
 from op import softmax_gpu_kernel, softmax_cpu_kernel
 
 alias SIZE = 128
-alias TPB = 128
-alias BLOCKS_PER_GRID = (1, 1)
-alias THREADS_PER_BLOCK = (TPB, 1)
 alias layout = Layout.row_major(SIZE)
+alias GRID_DIM_X = 1
+alias BLOCK_DIM_X = 1 << log2_ceil(SIZE)
 alias dtype = DType.float32
 
 
@@ -51,8 +51,8 @@ def test_softmax():
         ctx.enqueue_function[softmax_gpu_kernel[layout, SIZE, dtype]](
             output_tensor,
             input_tensor,
-            grid_dim=BLOCKS_PER_GRID,
-            block_dim=THREADS_PER_BLOCK,
+            grid_dim=GRID_DIM_X,
+            block_dim=BLOCK_DIM_X,
         )
 
         ctx.synchronize()

--- a/solutions/p19/op/attention.mojo
+++ b/solutions/p19/op/attention.mojo
@@ -4,6 +4,7 @@ from gpu.host import DeviceContext, HostBuffer, DeviceBuffer
 from layout import Layout, LayoutTensor
 from layout.tensor_builder import LayoutTensorBuild as tb
 from math import exp
+from bit import log2_ceil
 from utils.numerics import max_finite, min_finite
 import compiler
 from runtime.asyncrt import DeviceContextPtr
@@ -11,9 +12,10 @@ from tensor import InputTensor, OutputTensor
 from gpu.memory import async_copy_wait_all
 from layout.layout_tensor import copy_dram_to_sram_async
 
-alias SEQ_LEN = 16
-alias D = 16
-alias TPB = SEQ_LEN
+alias SEQ_LEN = 16 # This must be equal to SEQ_LEN in p19.py
+alias D = 16 # This must be equal to D in p19.py
+alias SOFTMAX_BLOCK_DIM_X = 1 << log2_ceil(SEQ_LEN)
+alias TPB = 16
 
 
 # Tiled matrix multiplication from p14 - adapted for attention
@@ -117,51 +119,46 @@ fn softmax_gpu_kernel[
     output: LayoutTensor[mut=True, dtype, layout],
     input: LayoutTensor[mut=False, dtype, layout],
 ):
-    shared_max = tb[dtype]().row_major[TPB]().shared().alloc()
-    shared_sum = tb[dtype]().row_major[TPB]().shared().alloc()
-    global_i = block_dim.x * block_idx.x + thread_idx.x
-    local_i = thread_idx.x
+    shared_max = tb[dtype]().row_major[SOFTMAX_BLOCK_DIM_X]().shared().alloc()
+    shared_sum = tb[dtype]().row_major[SOFTMAX_BLOCK_DIM_X]().shared().alloc()
+    global_i = thread_idx.x
 
-    var thread_max: Scalar[dtype] = min_finite[dtype]()
+    # Initialize out-of-bounds (shared_max[local_i], global_i >= input_size) shared memory addresses to the minimum
+    # finite value for dtype, ensuring that if these elements are accessed in the parallel max reduction below they
+    # do not influence the result (max(min_finite, x) == x for any x).
+    var val: Scalar[dtype] = min_finite[dtype]()
     if global_i < input_size:
-        thread_max = rebind[Scalar[dtype]](input[global_i])
+        val = rebind[Scalar[dtype]](input[global_i])
+    shared_max[global_i] = val
 
-    shared_max[local_i] = thread_max
     barrier()
 
     # Parallel reduction to find max similar to reduction we saw before
-    # Note we need to avoid race conditions by reading the value first and then writing
-    stride = TPB // 2
+    stride = SOFTMAX_BLOCK_DIM_X // 2
     while stride > 0:
-        var temp_max: Scalar[dtype] = min_finite[dtype]()
-        if local_i < stride:
-            temp_max = rebind[Scalar[dtype]](shared_max[local_i + stride])
-        barrier()
-        if local_i < stride:
-            shared_max[local_i] = max(shared_max[local_i], temp_max)
+        if global_i < stride:
+            shared_max[global_i] = max(
+                shared_max[global_i], shared_max[global_i + stride]
+            )
         barrier()
         stride = stride // 2
 
     block_max = shared_max[0]
 
+    # Initialize out-of-bounds (shared_max[global_i], global_i >= input_size) shared memory addresses to 0.0,
+    # ensuring that if these elements are accessed in the parallel sum reduction below they
+    # do not influence the result (adding 0.0 does not change the sum).
     var exp_val: Scalar[dtype] = 0.0
     if global_i < input_size:
-        exp_val = rebind[Scalar[dtype]](exp(input[global_i] - block_max))
-        output[global_i] = exp_val
-
-    shared_sum[local_i] = exp_val
+        exp_val = rebind[Scalar[dtype]](exp(val - block_max))
+    shared_sum[global_i] = exp_val
     barrier()
 
     # Parallel reduction for sum similar to reduction we saw before
-    # Note we need to avoid race conditions by reading the value first and then writing
-    stride = TPB // 2
+    stride = SOFTMAX_BLOCK_DIM_X // 2
     while stride > 0:
-        var temp_sum: Scalar[dtype] = 0.0
-        if local_i < stride:
-            temp_sum = rebind[Scalar[dtype]](shared_sum[local_i + stride])
-        barrier()
-        if local_i < stride:
-            shared_sum[local_i] += temp_sum
+        if global_i < stride:
+            shared_sum[global_i] += shared_sum[global_i + stride]
         barrier()
         stride = stride // 2
 
@@ -169,7 +166,7 @@ fn softmax_gpu_kernel[
 
     # Normalize by sum
     if global_i < input_size:
-        output[global_i] = output[global_i] / block_sum
+        output[global_i] = exp_val / block_sum
 
 
 # CPU implementation for vector attention
@@ -279,6 +276,8 @@ struct AttentionCustomOp:
                 (seq_len + TPB - 1) // TPB,
                 (1 + TPB - 1) // TPB,
             )
+            alias softmax_threads = SOFTMAX_BLOCK_DIM_X
+            alias softmax_blocks_per_grid = 1
             alias result_blocks_per_grid = (
                 (d + TPB - 1) // TPB,
                 (1 + TPB - 1) // TPB,
@@ -341,8 +340,8 @@ struct AttentionCustomOp:
             ](
                 weights,
                 weights,
-                grid_dim=(1, 1),
-                block_dim=(seq_len, 1),
+                grid_dim=softmax_blocks_per_grid,
+                block_dim=softmax_threads,
             )
 
             # Step 6: Reshape weights from (seq_len,) to (1, seq_len) for final matmul

--- a/solutions/p19/p19.py
+++ b/solutions/p19/p19.py
@@ -192,8 +192,8 @@ def test_individual_operations():
 
 
 if __name__ == "__main__":
-    SEQ_LEN = 16  # Number of key/value vectors
-    D = 16  # Dimension of each vector
+    SEQ_LEN = 16  # Number of key/value vectors, must be equal to SEQ_LEN in attention.mojo
+    D = 16  # Dimension of each vector, must be equal to D in attention.mojo
 
     cpu_session = InferenceSession(devices=[CPU()])
     gpu_session = InferenceSession(devices=[Accelerator()])


### PR DESCRIPTION
As well as using a consistent verison of softmax in both puzzles this PR tries to make the implementation cleaner by:

1. Removing explicit double read from global memory `input[global_i]`
2. Making it explicit that this version of softmax only works on a single block i.e. No need to calculate position in grid (`block_dim.x * block_idx.x`) or use `local_i` and `global_i`
3. Use `input_size/seq_len` from calling function to avoid having to also adjust `SIZE` when these values change.
4. Force the correct number of threads.  Implementation dictates that the number of threads should be a power of 2 greater than or equal to the `input_size/seq_len` and not user defined.

@ehsanmok Should _problems/p18/test/test_softmax.mojo_ and _solutions/p18/test/test_softmax.mojo_ be deleted?