### PR TITLE
[Puzzles 19&22] Use consistent implementation of matmul

### DIFF
--- a/book/src/puzzle_19/puzzle_19.md
+++ b/book/src/puzzle_19/puzzle_19.md
@@ -49,14 +49,14 @@ Step 2: softmax(Scores) → Weights(1,16)  [sum = 1.0]
 Step 3: Weights(1,16) @ V(16,16) → Output(1,16) → reshape → Output(16,)
 ```
 
-**Key insight**: We reshape the query vector \\(Q\\) from shape \\((16,)\\) to \\((1,16)\\) so we can use matrix multiplication instead of manual dot products. This allows us to leverage the highly optimized tiled matmul kernel from Puzzle 16!
+**Key insight**: We reshape the query vector \\(Q\\) from shape \\((16,)\\) to \\((1,16)\\) so we can use matrix multiplication instead of manual dot products. This allows us to leverage the highly optimized tiled matmul kernel from Puzzle 18!
 
 Our GPU implementation **reuses and combines optimized kernels from previous puzzles**:
 - **[Tiled matrix multiplication from Puzzle 16](../puzzle_16/puzzle_16.md)** for efficient \\(Q \cdot K^T\\) and \\(\text{weights} \cdot V\\) operations
 - **Shared memory transpose** for computing \\(K^T\\) efficiently
 - **[Parallel softmax from Puzzle 18](../puzzle_18/puzzle_18.md)** for numerically stable attention weight computation
 
-> **🔄 Kernel Reuse Strategy**: This puzzle demonstrates how to build complex operations by combining proven, optimized kernels from previous puzzles. Rather than writing everything from scratch, we leverage the `matmul_idiomatic_tiled` from Puzzle 14 and `softmax_kernel` from Puzzle 16, showcasing the power of modular GPU kernel design.
+> **🔄 Kernel Reuse Strategy**: This puzzle demonstrates how to build complex operations by combining proven, optimized kernels from previous puzzles. Rather than writing everything from scratch, we leverage the `matmul_idiomatic_tiled` from Puzzle 16 and `softmax_kernel` from Puzzle 18, showcasing the power of modular GPU kernel design.
 
 ## Key concepts
 

--- a/problems/p22/op/layernorm_linear.mojo
+++ b/problems/p22/op/layernorm_linear.mojo
@@ -10,48 +10,60 @@ from runtime.asyncrt import DeviceContextPtr
 from tensor import InputTensor, OutputTensor
 from utils import StaticTuple
 
+alias MATMUL_BLOCK_DIM_XY = 16 # Square blocks for a, b and output
+alias MATMUL_NUM_THREADS = MATMUL_BLOCK_DIM_XY * MATMUL_BLOCK_DIM_XY
+alias MATMUL_BLOCK_DIM_COUNT = 2
 alias TPB = 16
 alias dtype = DType.float32
 
 
 # ANCHOR: matmul_idiomatic_tiled
-# Idiomatic tiled matmul from p14.mojo - adapted for [batch*seq, hidden] @ [hidden, output] -> [batch*seq, output]
+# Idiomatic tiled matmul from p19.mojo
 fn matmul_idiomatic_tiled[
     a_layout: Layout,
     b_layout: Layout,
     out_layout: Layout,
     rows: Int,
     cols: Int,
-    inner_dim: Int,
+    inner: Int,
+    dtype: DType = DType.float32,
 ](
-    output: LayoutTensor[mut=True, dtype, out_layout],
-    a: LayoutTensor[mut=False, dtype, a_layout],
-    b: LayoutTensor[mut=False, dtype, b_layout],
+    output: LayoutTensor[mut=False, dtype, out_layout, MutableAnyOrigin],
+    a: LayoutTensor[mut=False, dtype, a_layout, MutableAnyOrigin],
+    b: LayoutTensor[mut=False, dtype, b_layout, MutableAnyOrigin],
 ):
-    """Idiomatic tiled matmul following p14.mojo exactly."""
-    local_row = thread_idx.x
-    local_col = thread_idx.y
-    tiled_row = block_idx.y * TPB + local_row
-    tiled_col = block_idx.x * TPB + local_col
+    """Idiomatic tiled matrix multiplication from p19."""
+    local_row = thread_idx.y
+    local_col = thread_idx.x
+    tiled_row = block_idx.y * MATMUL_BLOCK_DIM_XY + local_row
+    tiled_col = block_idx.x * MATMUL_BLOCK_DIM_XY + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
-    out_tile = output.tile[TPB, TPB](block_idx.x, block_idx.y)
-    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc().fill(0)
-    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc().fill(0)
-
+    out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](block_idx.y, block_idx.x)
+    a_shared = tb[dtype]().row_major[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY]().shared().alloc()
+    b_shared = tb[dtype]().row_major[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY]().shared().alloc()
     var acc: output.element_type = 0
 
-    alias load_a_layout = Layout.row_major(1, TPB)
-    alias load_b_layout = Layout.row_major(TPB, 1)
+    alias load_a_layout = Layout.row_major(MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY)  # Coalesced loading
+    alias load_b_layout = Layout.row_major(MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY)  # Coalesced loading
 
-    for idx in range((inner_dim + TPB - 1) // TPB):
+    @parameter
+    for idx in range((inner + MATMUL_BLOCK_DIM_XY - 1) // MATMUL_BLOCK_DIM_XY):
         # Get tiles from A and B matrices
-        a_tile = a.tile[TPB, TPB](block_idx.x, idx)
-        b_tile = b.tile[TPB, TPB](idx, block_idx.y)
+        a_tile = a.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](block_idx.y, idx)
+        b_tile = b.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](idx, block_idx.x)
 
-        # Asynchronously copy tiles to shared memory
-        copy_dram_to_sram_async[thread_layout=load_a_layout](a_shared, a_tile)
-        copy_dram_to_sram_async[thread_layout=load_b_layout](b_shared, b_tile)
+        # Asynchronously copy tiles to shared memory with consistent orientation
+        copy_dram_to_sram_async[
+            thread_layout=load_a_layout,
+            num_threads=MATMUL_NUM_THREADS,
+            block_dim_count=MATMUL_BLOCK_DIM_COUNT,
+        ](a_shared, a_tile)
+        copy_dram_to_sram_async[
+            thread_layout=load_b_layout,
+            num_threads=MATMUL_NUM_THREADS,
+            block_dim_count=MATMUL_BLOCK_DIM_COUNT,
+        ](b_shared, b_tile)
 
         # Wait for all async copies to complete
         async_copy_wait_all()
@@ -59,8 +71,10 @@ fn matmul_idiomatic_tiled[
 
         # Compute partial matrix multiplication for this tile
         @parameter
-        for k in range(TPB):
-            acc += a_shared[local_row, k] * b_shared[k, local_col]
+        for k in range(MATMUL_BLOCK_DIM_XY):
+            if(tiled_row < rows and tiled_col < cols): # Only perform calculation for valid outputs
+                if(k < a_tile.dim(1)): # Only perform calculation on valid inputs
+                    acc += a_shared[local_row, k] * b_shared[k, local_col]
 
         barrier()
 

--- a/solutions/p19/op/attention.mojo
+++ b/solutions/p19/op/attention.mojo
@@ -14,46 +14,64 @@ from layout.layout_tensor import copy_dram_to_sram_async
 
 alias SEQ_LEN = 16  # This must be equal to SEQ_LEN in p19.py
 alias D = 16  # This must be equal to D in p19.py
+alias MATMUL_BLOCK_DIM_XY = 16  # Square blocks for a, b and output
+alias MATMUL_NUM_THREADS = MATMUL_BLOCK_DIM_XY * MATMUL_BLOCK_DIM_XY
+alias MATMUL_BLOCK_DIM_COUNT = 2
 alias SOFTMAX_BLOCK_DIM_X = 1 << log2_ceil(SEQ_LEN)
 alias TPB = 16
 
-
-# Tiled matrix multiplication from p14 - adapted for attention
+# Tiled matrix multiplication (from p16), updated to:
+# 1) Support different layouts for input (a, b) and output LayoutTensors.
+# 2) Handle cases where the inner dimension is not a multiple of MATMUL_BLOCK_DIM_XY.
+# 3) Explicitly check for out-of-bounds elements.
+# The approach still tiles all three LayoutTensors (a, b, and output) into identical square tiles
+# of size (MATMUL_BLOCK_DIM_XY x MATMUL_BLOCK_DIM_XY) with each thread loading one element
+# from a and b, and writing one element to output.
 fn matmul_idiomatic_tiled[
-    layout: Layout,
+    a_layout: Layout,
+    b_layout: Layout,
+    out_layout: Layout,
     rows: Int,
     cols: Int,
     inner: Int,
     dtype: DType = DType.float32,
 ](
-    output: LayoutTensor[mut=False, dtype, layout, MutableAnyOrigin],
-    a: LayoutTensor[mut=False, dtype, layout, MutableAnyOrigin],
-    b: LayoutTensor[mut=False, dtype, layout, MutableAnyOrigin],
+    output: LayoutTensor[mut=False, dtype, out_layout, MutableAnyOrigin],
+    a: LayoutTensor[mut=False, dtype, a_layout, MutableAnyOrigin],
+    b: LayoutTensor[mut=False, dtype, b_layout, MutableAnyOrigin],
 ):
-    """Idiomatic tiled matrix multiplication from p14."""
+    """Updated idiomatic tiled matrix multiplication from p16."""
     local_row = thread_idx.y
     local_col = thread_idx.x
-    tiled_row = block_idx.y * TPB + local_row
-    tiled_col = block_idx.x * TPB + local_col
+    tiled_row = block_idx.y * MATMUL_BLOCK_DIM_XY + local_row
+    tiled_col = block_idx.x * MATMUL_BLOCK_DIM_XY + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
-    output_tile = output.tile[TPB, TPB](block_idx.y, block_idx.x)
-    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc().fill(0)
-    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc().fill(0)
-
+    out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](block_idx.y, block_idx.x)
+    a_shared = tb[dtype]().row_major[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY]().shared().alloc()
+    b_shared = tb[dtype]().row_major[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY]().shared().alloc()
     var acc: output.element_type = 0
 
-    alias load_a_layout = Layout.row_major(1, TPB)
-    alias load_b_layout = Layout.row_major(TPB, 1)
+    alias load_a_layout = Layout.row_major(MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY)  # Coalesced loading
+    alias load_b_layout = Layout.row_major(MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY)  # Coalesced loading
 
-    for idx in range((inner + TPB - 1) // TPB):
+    @parameter
+    for idx in range((inner + MATMUL_BLOCK_DIM_XY - 1) // MATMUL_BLOCK_DIM_XY):
         # Get tiles from A and B matrices
-        a_tile = a.tile[TPB, TPB](block_idx.y, idx)
-        b_tile = b.tile[TPB, TPB](idx, block_idx.x)
+        a_tile = a.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](block_idx.y, idx)
+        b_tile = b.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](idx, block_idx.x)
 
-        # Asynchronously copy tiles to shared memory
-        copy_dram_to_sram_async[thread_layout=load_a_layout](a_shared, a_tile)
-        copy_dram_to_sram_async[thread_layout=load_b_layout](b_shared, b_tile)
+        # Asynchronously copy tiles to shared memory with consistent orientation
+        copy_dram_to_sram_async[
+            thread_layout=load_a_layout,
+            num_threads=MATMUL_NUM_THREADS,
+            block_dim_count=MATMUL_BLOCK_DIM_COUNT,
+        ](a_shared, a_tile)
+        copy_dram_to_sram_async[
+            thread_layout=load_b_layout,
+            num_threads=MATMUL_NUM_THREADS,
+            block_dim_count=MATMUL_BLOCK_DIM_COUNT,
+        ](b_shared, b_tile)
 
         # Wait for all async copies to complete
         async_copy_wait_all()
@@ -61,14 +79,16 @@ fn matmul_idiomatic_tiled[
 
         # Compute partial matrix multiplication for this tile
         @parameter
-        for k in range(TPB):
-            acc += a_shared[local_row, k] * b_shared[k, local_col]
+        for k in range(MATMUL_BLOCK_DIM_XY):
+            if(tiled_row < rows and tiled_col < cols): # Only perform calculation for valid outputs
+                if(k < a_tile.dim(1)): # Only perform calculation on valid inputs
+                    acc += a_shared[local_row, k] * b_shared[k, local_col]
 
         barrier()
 
     # Write final result with bounds checking (needed for attention's variable sizes)
     if tiled_row < rows and tiled_col < cols:
-        output_tile[local_row, local_col] = acc
+        out_tile[local_row, local_col] = acc
 
 
 # ANCHOR: transpose_kernel_solution
@@ -219,7 +239,6 @@ fn attention_cpu_kernel[
             )
         output[dim] = rebind[Scalar[dtype]](weighted_sum)
 
-
 @compiler.register("attention")
 struct AttentionCustomOp:
     @staticmethod
@@ -272,17 +291,15 @@ struct AttentionCustomOp:
             # Result as (1, d)
             alias layout_result_2d = Layout.row_major(1, d)
 
-            alias scores_blocks_per_grid = (
-                (seq_len + TPB - 1) // TPB,
-                (1 + TPB - 1) // TPB,
-            )
+            # Matmul implementation limited to square (MATMUL_BLOCK_DIM_XY x MATMUL_BLOCK_DIM_XY) thread blocks
+            alias matmul_threads_per_block = (MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY)
+            # seq_len outputs ( Q @ K^T = (1, d) @ (d, seq_len) -> (1, seq_len) ) with one thread per output
+            alias scores_blocks_per_grid = (seq_len + MATMUL_BLOCK_DIM_XY - 1) // MATMUL_BLOCK_DIM_XY
             alias softmax_threads = SOFTMAX_BLOCK_DIM_X
             alias softmax_blocks_per_grid = 1
-            alias result_blocks_per_grid = (
-                (d + TPB - 1) // TPB,
-                (1 + TPB - 1) // TPB,
-            )
-            alias matmul_threads_per_block = (TPB, TPB)
+            # d outputs ( weights @ V = (1, seq_len) @ (seq_len, d) -> (1, d) ) with one thread per output
+            alias result_blocks_per_grid = (d + MATMUL_BLOCK_DIM_XY - 1) // MATMUL_BLOCK_DIM_XY
+            alias transpose_threads_per_block = (TPB, TPB)
             alias transpose_blocks_per_grid = (
                 (seq_len + TPB - 1) // TPB,
                 (d + TPB - 1) // TPB,
@@ -312,7 +329,7 @@ struct AttentionCustomOp:
                 k_t,
                 k_tensor,
                 grid_dim=transpose_blocks_per_grid,
-                block_dim=matmul_threads_per_block,
+                block_dim=transpose_threads_per_block,
             )
 
             # Step 3: Compute attention scores using matmul: Q @ K^T = (1, d) @ (d, seq_len) -> (1, seq_len)
@@ -322,7 +339,7 @@ struct AttentionCustomOp:
                 mut=True, dtype, layout_scores_2d, MutableAnyOrigin
             ](scores_weights_buf.unsafe_ptr())
             gpu_ctx.enqueue_function[
-                matmul_idiomatic_tiled[layout_q_2d, 1, seq_len, d, dtype]
+                matmul_idiomatic_tiled[layout_q_2d, layout_k_t, layout_scores_2d, 1, seq_len, d, dtype]
             ](
                 scores_2d,
                 q_2d,
@@ -351,7 +368,7 @@ struct AttentionCustomOp:
             # Reuse out_tensor reshaped as (1, d) for result
             result_2d = output_tensor.reshape[layout_result_2d]()
             gpu_ctx.enqueue_function[
-                matmul_idiomatic_tiled[layout_weights_2d, 1, d, seq_len, dtype]
+                matmul_idiomatic_tiled[layout_weights_2d, layout_v, layout_result_2d, 1, d, seq_len, dtype]
             ](
                 result_2d,
                 weights_2d,


### PR DESCRIPTION
Update puzzles 19 and 22 to use the version of matmul from puzzle 16 as their base implementation.  The puzzle 16 implementation needs minor updates to work with:
1) Inputs and outputs with different layouts. **Added in PR**
2) Inner dimensions that are not a multiples of `MATMUL_BLOCK_DIM_XY`. **Already present**

Additonaly:
- I've tried to make it more explicit that this implementation uses a simple fixed tiling approach (`MATMUL_BLOCK_DIM_XY x MATMUL_BLOCK_DIM_XY` square tiles for all LayoutTensors). i.e There is no concept of different (BN, BM, BK)  tile sizes for `a`, `b` and `output`.
- Added explicit checks for out of bound input and output elements which is not strictly necessary because `copy_dram_to_sram_async` fills out of bound elements with zeros.

<hr>

**Edit:** Fixed layernorm_linear matmul block dims.