### PR TITLE
[Puzzles 19&21] Use consistent implementation of transpose

### DIFF
--- a/book/src/puzzle_19/puzzle_19.md
+++ b/book/src/puzzle_19/puzzle_19.md
@@ -115,11 +115,11 @@ To complete this puzzle, we'll leverage the tiled matmul kernel from [Puzzle 16]
 
 **Transpose Kernel Implementation Guide:**
 
-1. **Shared Memory Setup**: Use `tb[dtype]().row_major[TPB, TPB]().shared().alloc()` to create a TPB×TPB shared memory tile for efficient data exchange between threads
+1. **Shared Memory Setup**: Use `tb[dtype]().row_major[TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY]().shared().alloc()` to create a square `TRANSPOSE_BLOCK_DIM_XY` × `TRANSPOSE_BLOCK_DIM_XY` shared memory tile for efficient data exchange between threads
 
 2. **Thread Indexing**: Map threads to matrix elements:
    - `local_row = thread_idx.y`, `local_col = thread_idx.x` (position within the block)
-   - `global_row = block_idx.y * TPB + local_row` (position in the full matrix)
+   - `global_row = block_idx.y * TRANSPOSE_BLOCK_DIM_XY + local_row` (position in the full matrix)
 
 3. **Two-Phase Operation**:
    - **Phase 1**: Load data from global memory into shared memory with normal indexing
@@ -129,7 +129,7 @@ To complete this puzzle, we'll leverage the tiled matmul kernel from [Puzzle 16]
 
 5. **Transpose Magic**: The transpose happens through swapped indexing: `shared_tile[local_col, local_row]` instead of `shared_tile[local_row, local_col]`
 
-6. **Boundary Handling**: Check bounds when accessing global memory to avoid out-of-bounds reads/writes for matrices that don't perfectly divide by TPB
+6. **Boundary Handling**: Check bounds when accessing global memory to avoid out-of-bounds reads/writes for matrices that don't perfectly divide by `TRANSPOSE_BLOCK_DIM_XY` x `TRANSPOSE_BLOCK_DIM_XY`
 
 7. **Memory Coalescing**: This pattern ensures both reads and writes are coalesced for optimal memory bandwidth utilization
 </div>

--- a/problems/p19/op/attention.mojo
+++ b/problems/p19/op/attention.mojo
@@ -14,11 +14,12 @@ from layout.layout_tensor import copy_dram_to_sram_async
 
 alias SEQ_LEN = 16  # This must be equal to SEQ_LEN in p19.py
 alias D = 16  # This must be equal to D in p19.py
+
+alias TRANSPOSE_BLOCK_DIM_XY = 16  # Square blocks for input and output
 alias MATMUL_BLOCK_DIM_XY = 16  # Square blocks for a, b and output
 alias MATMUL_NUM_THREADS = MATMUL_BLOCK_DIM_XY * MATMUL_BLOCK_DIM_XY
 alias MATMUL_BLOCK_DIM_COUNT = 2
 alias SOFTMAX_BLOCK_DIM_X = 1 << log2_ceil(SEQ_LEN)
-alias TPB = 16
 
 # Tiled matrix multiplication (from p16), updated to:
 # 1) Support different layouts for input (a, b) and output LayoutTensors.
@@ -272,6 +273,13 @@ struct AttentionCustomOp:
             # Result as (1, d)
             alias layout_result_2d = Layout.row_major(1, d)
 
+            # Transpose implementation limited to square (TRANSPOSE_BLOCK_DIM_XY x TRANSPOSE_BLOCK_DIM_XY) thread blocks
+            alias transpose_threads_per_block = (TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY)
+            # Tile over the K (seq_len, d) matrix
+            alias transpose_blocks_per_grid = (
+                (d + TRANSPOSE_BLOCK_DIM_XY - 1) // TRANSPOSE_BLOCK_DIM_XY,
+                (seq_len + TRANSPOSE_BLOCK_DIM_XY - 1) // TRANSPOSE_BLOCK_DIM_XY
+            )
             # Matmul implementation limited to square (MATMUL_BLOCK_DIM_XY x MATMUL_BLOCK_DIM_XY) thread blocks
             alias matmul_threads_per_block = (MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY)
             # seq_len outputs ( Q @ K^T = (1, d) @ (d, seq_len) -> (1, seq_len) ) with one thread per output
@@ -280,11 +288,6 @@ struct AttentionCustomOp:
             alias softmax_blocks_per_grid = 1
             # d outputs ( weights @ V = (1, seq_len) @ (seq_len, d) -> (1, d) ) with one thread per output
             alias result_blocks_per_grid = (d + MATMUL_BLOCK_DIM_XY - 1) // MATMUL_BLOCK_DIM_XY
-            alias transpose_threads_per_block = (TPB, TPB)
-            alias transpose_blocks_per_grid = (
-                (seq_len + TPB - 1) // TPB,
-                (d + TPB - 1) // TPB,
-            )
 
             # Allocate minimal temporary buffers - reuse same buffer for different shapes
             k_t_buf = gpu_ctx.enqueue_create_buffer[dtype](

--- a/solutions/p22/op/layernorm_linear.mojo
+++ b/solutions/p22/op/layernorm_linear.mojo
@@ -10,9 +10,10 @@ from runtime.asyncrt import DeviceContextPtr
 from tensor import InputTensor, OutputTensor
 from utils import StaticTuple
 
-alias MATMUL_BLOCK_DIM_XY = 16 # Square blocks for a, b and output
+alias MATMUL_BLOCK_DIM_XY = 16  # Square blocks for a, b and output
 alias MATMUL_NUM_THREADS = MATMUL_BLOCK_DIM_XY * MATMUL_BLOCK_DIM_XY
 alias MATMUL_BLOCK_DIM_COUNT = 2
+alias TRANSPOSE_BLOCK_DIM_XY = 16  # Square blocks for input and output
 alias TPB = 16
 alias dtype = DType.float32
 
@@ -136,34 +137,35 @@ fn layernorm_kernel[
 # ANCHOR_END: layernorm_kernel_solution
 
 
-# ANCHOR: transpose_kernel
+# ANCHOR: transpose_kernel_solution
 fn transpose_kernel[
     layout_in: Layout,
     layout_out: Layout,
     rows: Int,
     cols: Int,
+    dtype: DType = DType.float32,
 ](
-    output: LayoutTensor[mut=True, dtype, layout_out],
-    input: LayoutTensor[mut=False, dtype, layout_in],
+    output: LayoutTensor[mut=True, dtype, layout_out, MutableAnyOrigin],
+    inp: LayoutTensor[mut=False, dtype, layout_in, MutableAnyOrigin],
 ):
-    """Transpose matrix using shared memory tiling for coalesced access."""
-    shared_tile = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
+    """Transpose matrix using shared memory tiling for coalesced access.
+    We will learn more about coalesced access in the next part.
+    """
+    shared_tile = tb[dtype]().row_major[TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY]().shared().alloc()
 
     local_row = thread_idx.y
     local_col = thread_idx.x
 
-    global_row = block_idx.y * TPB + local_row
-    global_col = block_idx.x * TPB + local_col
+    global_row = block_idx.y * TRANSPOSE_BLOCK_DIM_XY + local_row
+    global_col = block_idx.x * TRANSPOSE_BLOCK_DIM_XY + local_col
 
     if global_row < rows and global_col < cols:
-        shared_tile[local_row, local_col] = input[global_row, global_col]
-    else:
-        shared_tile[local_row, local_col] = 0.0
+        shared_tile[local_row, local_col] = inp[global_row, global_col]
 
     barrier()
 
-    out_row = block_idx.x * TPB + local_row
-    out_col = block_idx.y * TPB + local_col
+    out_row = block_idx.x * TRANSPOSE_BLOCK_DIM_XY + local_row
+    out_col = block_idx.y * TRANSPOSE_BLOCK_DIM_XY + local_col
 
     # Store data from shared memory to global memory (coalesced write)
     # Note: we transpose the shared memory access pattern
@@ -171,7 +173,7 @@ fn transpose_kernel[
         output[out_row, out_col] = shared_tile[local_col, local_row]
 
 
-# ANCHOR_END: transpose_kernel
+# ANCHOR_END: transpose_kernel_solution
 
 
 # ANCHOR: add_bias_kernel
@@ -542,8 +544,8 @@ struct LayerNormLinearCustomOp:
                 ](transposed_weight_buffer.unsafe_ptr())
 
                 # Transpose the weight matrix
-                transpose_blocks_x = (hidden_dim + TPB - 1) // TPB
-                transpose_blocks_y = (output_dim + TPB - 1) // TPB
+                transpose_blocks_x = (hidden_dim + TRANSPOSE_BLOCK_DIM_XY - 1) // TRANSPOSE_BLOCK_DIM_XY
+                transpose_blocks_y = (output_dim + TRANSPOSE_BLOCK_DIM_XY - 1) // TRANSPOSE_BLOCK_DIM_XY
                 gpu_ctx.enqueue_function[
                     transpose_kernel[
                         weight_layout,
@@ -555,7 +557,7 @@ struct LayerNormLinearCustomOp:
                     transposed_weight_tensor,
                     linear_weight_tensor,
                     grid_dim=(transpose_blocks_x, transpose_blocks_y),
-                    block_dim=(TPB, TPB),
+                    block_dim=(TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY),
                 )
 
                 # Reshape tensors for matmul: [batch*seq, hidden] @ [hidden, output] -> [batch*seq, output]


### PR DESCRIPTION
Update puzzles 19 and 22 to use a consistent updated version of the transpose kernel from puzzle 19.  Current implementation updated:
1. To use new `TRANSPOSE_BLOCK_DIM_XY` alias instead of `TPB`, explicitely indicating that this implementation requires square blocks.
2. Remove unecessary shared memory initialization when `global_row > rows` or `global_col > cols` as this is addressed when the tile is written back to global memory.
3. Fix incorret launch parameters in puzzle 19.