### PR TITLE
ayoutTensor -> LayoutTensor

### DIFF
--- a/book/src/puzzle_08/layout_tensor.md
+++ b/book/src/puzzle_08/layout_tensor.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Implement a kernel that adds 10 to each position of a 1D ayoutTensor `a` and stores it in 1D LayoutTensor `output`.
+Implement a kernel that adds 10 to each position of a 1D LayoutTensor `a` and stores it in 1D LayoutTensor `output`.
 
 **Note:** _You have fewer threads per block than the size of `a`._
 


### PR DESCRIPTION
Was just going through the puzzles and found a typo in p08. 

`ayoutTensor` should be `LayoutTensor`