### PR TITLE
Added manim dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [[tool.uv.index]]
-url = "https://dl.modular.com/public/nightly/python/simple/"
+url = "https://dl.modular.com/public/nightly/python/simple/mojo-compiler"
 prerelease = "allow"
 
 [[tool.uv.index]]


### PR DESCRIPTION
The manim library dependency was missing from pyproject.toml. This MR adds it.