### PR TITLE
Fixed moji compiler path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [[tool.uv.index]]
-url = "https://dl.modular.com/public/nightly/python/simple/"
+url = "https://dl.modular.com/public/nightly/python/simple/mojo-compiler"
 prerelease = "allow"
 
 [[tool.uv.index]]


### PR DESCRIPTION
`uv sync` was failing with:

```
uv sync
⠙ mojo-compiler==0.25.6.0.dev2025091505                                         error: Failed to fetch: `https://dl.modular.com/public/nightly/python/mojo_compiler-0.25.6.0.dev2025091505-py3-none-macosx_13_0_arm64.whl`
  Caused by: HTTP status client error (404 Not Found) for url (https://dl.modular.com/public/nightly/python/mojo_compiler-0.25.6.0.dev2025091505-py3-none-macosx_13_0_arm64.whl)
```

This MR fixes that.