### PR TITLE
Change color names in p16 roofline.md to reflect what is being shown

### DIFF
--- a/book/src/puzzle_16/roofline.md
+++ b/book/src/puzzle_16/roofline.md
@@ -60,8 +60,8 @@ The animation below shows how our puzzle implementations map onto the A100's roo
 The visualization demonstrates the optimization journey we'll take in this puzzle:
 
 1. **Hardware constraints** – The red memory roof and blue compute roof define performance limits
-2. **Our starting point** – The naive implementation (left purple dot) sitting firmly on the memory roof
-3. **Optimization target** – The shared memory version (right purple dot) with improved arithmetic intensity
+2. **Our starting point** – The naive implementation (orange dot) sitting firmly on the memory roof
+3. **Optimization target** – The shared memory version (teal dot) with improved arithmetic intensity
 4. **Ultimate goal** – The golden arrow pointing toward the critical intensity where kernels become compute-bound
 
 ## 4. Analyzing our naive implementation


### PR DESCRIPTION
The colors don't match the image. 

I looked into `roofline_viz.py` and confirmed the names there as orange and teal. 

I removed the left/right distinction, but happy to put it back if you feel it's needed. 

Arrow looks orange to my eye, but color is actually called GOLD, so leaving it as is. 