### PR TITLE
Add backslash to escape percentage

### DIFF
--- a/book/src/puzzle_16/roofline.md
+++ b/book/src/puzzle_16/roofline.md
@@ -87,7 +87,7 @@ Since \\(I_{\text{naive}} = 0.1875 \ll I^* = 12.5\\), our naive kernel is **seve
 **Expected performance**:
 \\[\Large P \approx B_{\text{peak}} \times I_{\text{naive}} = 1{,}555 \times 0.1875 \approx 292 \text{ GFLOP/s}\\]
 
-This represents only \\(\frac{292}{19{,}500} \approx 1.5\%\\) of the GPU's computational potential! The visualization clearly shows this as the leftmost purple dot sitting squarely on the memory roof—we're nowhere near the compute ceiling.
+This represents only \\(\frac{292}{19{,}500} \approx 1.5\\%\\) of the GPU's computational potential! The visualization clearly shows this as the leftmost purple dot sitting squarely on the memory roof—we're nowhere near the compute ceiling.
 
 ## 5. The path forward: shared memory optimization
 


### PR DESCRIPTION
Not 100% sure how your rendering engine deals with it, but currently the percentage sign doesn't show. 

I (and Claude) think you need an extra backslash to properly escape it. 

(btw, sorry for all the separate PRs, I just kinda do them as I see them, I can try bundling them if you prefer?)