### PR TITLE
Refactor: Migrate from LayoutTensorBuild to LayoutTensor with explicit address_space

### DIFF
--- a/book/src/puzzle_08/layout_tensor.md
+++ b/book/src/puzzle_08/layout_tensor.md
@@ -8,9 +8,9 @@ Implement a kernel that adds 10 to each position of a 1D LayoutTensor `a` and st
 
 In this puzzle, you'll learn about:
 
-- Using LayoutTensor's shared memory features
+- Using LayoutTensor's shared memory features with address_space
 - Thread synchronization with shared memory
-- Block-local data management with tensor builder
+- Block-local data management with LayoutTensor
 
 The key insight is how LayoutTensor simplifies shared memory management while maintaining the performance benefits of block-local storage.
 
@@ -23,14 +23,14 @@ The key insight is how LayoutTensor simplifies shared memory management while ma
 
 ## Key differences from raw approach
 
-1. **Memory allocation**: We will use [LayoutTensorBuild](https://docs.modular.com/mojo/stdlib/layout/tensor_builder/LayoutTensorBuild) instead of [stack_allocation](https://docs.modular.com/mojo/stdlib/memory/memory/stack_allocation/)
+1. **Memory allocation**: We will use [LayoutTensor](https://docs.modular.com/mojo/stdlib/layout/layout_tensor/LayoutTensor) with address_space instead of [stack_allocation](https://docs.modular.com/mojo/stdlib/memory/memory/stack_allocation/)
 
    ```mojo
    # Raw approach
    shared = stack_allocation[TPB, Scalar[dtype]]()
 
    # LayoutTensor approach
-   shared = LayoutTensorBuild[dtype]().row_major[TPB]().shared().alloc()
+   shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
    ```
 
 2. **Memory access**: Same syntax
@@ -66,7 +66,7 @@ The key insight is how LayoutTensor simplifies shared memory management while ma
 
 <div class="solution-tips">
 
-1. Create shared memory with tensor builder
+1. Create shared memory with LayoutTensor using address_space parameter
 2. Load data with natural indexing: `shared[local_i] = a[global_i]`
 3. Synchronize with `barrier()` (educational - not strictly needed here)
 4. Process data using shared memory indices
@@ -167,8 +167,8 @@ This solution demonstrates how LayoutTensor simplifies shared memory usage while
    - Shared memory allocation:
 
      ```txt
-     # Clean tensor builder API
-     shared = tb[dtype]().row_major[TPB]().shared().alloc()
+     # Clean LayoutTensor API with address_space
+     shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
      ```
 
    - Natural indexing for both global and shared:

--- a/book/src/puzzle_09/third_case.md
+++ b/book/src/puzzle_09/third_case.md
@@ -22,7 +22,7 @@ ln -sf /usr/local/cuda/bin/cuda-gdb-python3.12-tui $CONDA_PREFIX/bin/cuda-gdb-py
 
 In this debugging challenge, you'll learn about:
 - **Barrier deadlock detection**: Identifying when threads wait forever at synchronization points
-- **Shared memory coordination**: Understanding thread cooperation patterns
+- **Shared memory coordination**: Understanding thread cooperation patterns with LayoutTensor
 - **Conditional execution analysis**: Debugging when some threads take different code paths
 - **Thread coordination debugging**: Using CUDA-GDB to analyze multi-thread synchronization failures
 

--- a/book/src/puzzle_11/layout_tensor.md
+++ b/book/src/puzzle_11/layout_tensor.md
@@ -9,7 +9,7 @@ Implement a kernel that compute the running sum of the last 3 positions of 1D La
 In this puzzle, you'll learn about:
 
 - Using LayoutTensor for sliding window operations
-- Managing shared memory with `LayoutTensorBuilder` that we saw in [puzzle_08](../puzzle_08/layout_tensor.md)
+- Managing shared memory with LayoutTensor address_space that we saw in [puzzle_08](../puzzle_08/layout_tensor.md)
 - Efficient neighbor access patterns
 - Boundary condition handling
 
@@ -24,7 +24,7 @@ The key insight is how LayoutTensor simplifies shared memory management while ma
 
 Notes:
 
-- **Tensor builder**: Use `LayoutTensorBuilder[dtype]().row_major[TPB]().shared().alloc()`
+- **LayoutTensor allocation**: Use `LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()`
 - **Window access**: Natural indexing for 3-element windows
 - **Edge handling**: Special cases for first two positions
 - **Memory pattern**: One shared memory load per thread
@@ -42,7 +42,7 @@ Notes:
 
 <div class="solution-tips">
 
-1. Create shared memory with tensor builder
+1. Create shared memory with LayoutTensor using address_space
 2. Load data with natural indexing: `shared[local_i] = a[global_i]`
 3. Handle special cases for first two elements
 4. Use shared memory for window operations
@@ -113,10 +113,10 @@ expected: HostBuffer([0.0, 1.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0])
 The solution implements a sliding window sum using LayoutTensor with these key steps:
 
 1. **Shared memory setup**
-   - Tensor builder creates block-local storage:
+   - LayoutTensor creates block-local storage with address_space:
 
      ```txt
-     shared = tb[dtype]().row_major[TPB]().shared().alloc()
+     shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
      ```
 
    - Each thread loads one element:

--- a/book/src/puzzle_12/layout_tensor.md
+++ b/book/src/puzzle_12/layout_tensor.md
@@ -9,7 +9,7 @@ Implement a kernel that computes the dot product of 1D LayoutTensor `a` and 1D L
 This puzzle covers:
 
 - Similar to the [puzzle 8](../puzzle_08/layout_tensor.md) and [puzzle 11](../puzzle_11/layout_tensor.md), implementing parallel reduction with LayoutTensor
-- Managing shared memory using `LayoutTensorBuilder`
+- Managing shared memory using LayoutTensor with address_space
 - Coordinating threads for collective operations
 - Using layout-aware tensor operations
 
@@ -25,7 +25,7 @@ The key insight is how LayoutTensor simplifies memory management while maintaini
 
 Notes:
 
-- **Tensor builder**: Use `LayoutTensorBuilder[dtype]().row_major[TPB]().shared().alloc()`
+- **LayoutTensor allocation**: Use `LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()`
 - **Element access**: Natural indexing with bounds checking
 - **Layout handling**: Separate layouts for input and output
 - **Thread coordination**: Same synchronization patterns with `barrier()`
@@ -43,7 +43,7 @@ Notes:
 
 <div class="solution-tips">
 
-1. Create shared memory with tensor builder
+1. Create shared memory with LayoutTensor using address_space
 2. Store `a[global_i] * b[global_i]` in `shared[local_i]`
 3. Use parallel reduction pattern with `barrier()`
 4. Let thread 0 write final result to `output[0]`
@@ -141,7 +141,7 @@ Step 3:   [56+84  84   40   58   16   25   36   49]
 ### Key implementation features
 
 1. **Memory Management**:
-   - Clean shared memory allocation with tensor builder
+   - Clean shared memory allocation with LayoutTensor address_space parameter
    - Type-safe operations with LayoutTensor
    - Automatic bounds checking
    - Layout-aware indexing

--- a/book/src/puzzle_13/block_boundary.md
+++ b/book/src/puzzle_13/block_boundary.md
@@ -32,7 +32,7 @@ Notes:
 
 <div class="solution-tips">
 
-1. Use `tb[dtype]().row_major[TPB + CONV_2 - 1]().shared().alloc()` for shared memory
+1. Use `LayoutTensor[dtype, Layout.row_major(TPB + CONV_2 - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()` for shared memory
 2. Load main data: `shared_a[local_i] = a[global_i]`
 3. Load boundary: `if local_i < CONV_2 - 1` handle next block data
 4. Load kernel: `shared_b[local_i] = b[local_i]`
@@ -125,8 +125,8 @@ Size calculation:
 
    ```mojo
    # First: account for padding needed for convolution window
-   shared_a = tb[dtype]().row_major[TPB + CONV_2 - 1]().shared().alloc()
-   shared_b = tb[dtype]().row_major[CONV_2]().shared().alloc()
+   shared_a = LayoutTensor[dtype, Layout.row_major(TPB + CONV_2 - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+   shared_b = LayoutTensor[dtype, Layout.row_major(CONV_2), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
    ```
 
    This allocation pattern ensures we have enough space for both the block's data and the overlap region.

--- a/book/src/puzzle_13/puzzle_13.md
+++ b/book/src/puzzle_13/puzzle_13.md
@@ -5,7 +5,7 @@
 > So far in our GPU puzzle journey, we've been exploring two parallel approaches to GPU memory management:
 >
 > 1. Raw memory management with direct pointer manipulation using [UnsafePointer](https://docs.modular.com/mojo/stdlib/memory/unsafe_pointer/UnsafePointer/)
-> 2. The more structured [LayoutTensor](https://docs.modular.com/mojo/stdlib/layout/layout_tensor/LayoutTensor/) and its related abstractions such as [LayoutTensorBuild](https://docs.modular.com/mojo/stdlib/layout/tensor_builder/LayoutTensorBuild/)
+> 2. The more structured [LayoutTensor](https://docs.modular.com/mojo/stdlib/layout/layout_tensor/LayoutTensor/) with its powerful address_space parameter for memory allocation
 >
 > Starting from this puzzle, we're transitioning exclusively to using `LayoutTensor`. This abstraction provides several benefits:
 > - Type-safe memory access patterns

--- a/book/src/puzzle_14/simple.md
+++ b/book/src/puzzle_14/simple.md
@@ -14,7 +14,7 @@ Implement a kernel that computes a prefix-sum over 1D LayoutTensor `a` and store
 Notes:
 
 - **Data loading**: Each thread loads one element using LayoutTensor access
-- **Memory pattern**: Shared memory for intermediate results using `LayoutTensorBuild`
+- **Memory pattern**: Shared memory for intermediate results using LayoutTensor with address_space
 - **Thread sync**: Coordination between computation phases
 - **Access pattern**: Stride-based parallel computation
 - **Type safety**: Leveraging LayoutTensor's type system

--- a/book/src/puzzle_16/shared_memory.md
+++ b/book/src/puzzle_16/shared_memory.md
@@ -130,9 +130,9 @@ Matrix B:                           b_shared: (similar layout)
 1. **Shared Memory Setup**:
 
    ```mojo
-   # Create 2D shared memory tensors using TensorBuilder
-   a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
-   b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
+   # Create 2D shared memory tensors using LayoutTensor with address_space
+   a_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+   b_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
    ```
 
 2. **Thread Indexing**:
@@ -215,7 +215,7 @@ Matrix B:                           b_shared: (similar layout)
    - Efficient memory layout handling
 
 2. **Shared memory allocation**:
-   - TensorBuilder for structured allocation
+   - LayoutTensor with address_space for structured allocation
    - Row-major layout matching input tensors
    - Proper alignment for efficient access
 

--- a/book/src/puzzle_18/puzzle_18.md
+++ b/book/src/puzzle_18/puzzle_18.md
@@ -264,8 +264,8 @@ The kernel is parameterized with:
 #### Shared memory allocation
 
 ```mojo
-shared_max = tb[dtype]().row_major[BLOCK_DIM_X]().shared().alloc()
-shared_sum = tb[dtype]().row_major[BLOCK_DIM_X]().shared().alloc()
+shared_max = LayoutTensor[dtype, Layout.row_major(BLOCK_DIM_X), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+shared_sum = LayoutTensor[dtype, Layout.row_major(BLOCK_DIM_X), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 ```
 
 The kernel allocates two shared memory buffers:

--- a/book/src/puzzle_19/puzzle_19.md
+++ b/book/src/puzzle_19/puzzle_19.md
@@ -121,7 +121,7 @@ To complete this puzzle, we'll leverage the tiled matmul kernel from [Puzzle 16]
 
 **Transpose Kernel Implementation Guide:**
 
-1. **Shared Memory Setup**: Use `tb[dtype]().row_major[TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY]().shared().alloc()` to create a square `TRANSPOSE_BLOCK_DIM_XY` × `TRANSPOSE_BLOCK_DIM_XY` shared memory tile for efficient data exchange between threads
+1. **Shared Memory Setup**: Use `LayoutTensor[dtype, Layout.row_major(TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()` to create a square `TRANSPOSE_BLOCK_DIM_XY` × `TRANSPOSE_BLOCK_DIM_XY` shared memory tile for efficient data exchange between threads
 
 2. **Thread Indexing**: Map threads to matrix elements:
    - `local_row = thread_idx.y`, `local_col = thread_idx.x` (position within the block)

--- a/book/src/puzzle_32/conflict_free_patterns.md
+++ b/book/src/puzzle_32/conflict_free_patterns.md
@@ -354,7 +354,7 @@ constant = shared[0]  # All threads read same address - hardware optimized
 **3. Padding techniques:**
 
 ```mojo
-shared = tb[dtype]().row_major[TPB + 1]().shared().alloc()  # Shift access patterns
+shared = LayoutTensor[dtype, Layout.row_major(TPB + 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()  # Shift access patterns
 ```
 
 **4. Access pattern analysis:**

--- a/book/src/puzzle_34/cluster_coordination_basics.md
+++ b/book/src/puzzle_34/cluster_coordination_basics.md
@@ -65,7 +65,7 @@ Traditional single-block algorithms like those in [Puzzle 27](../puzzle_27/puzzl
 
 ### **Shared memory coordination**
 
-- Allocate shared memory using `tb[dtype]().row_major[tpb]().shared().alloc()` (see [shared memory basics from Puzzle 8](../puzzle_08/puzzle_08.md))
+- Allocate shared memory using `LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()` (see [shared memory basics from Puzzle 8](../puzzle_08/puzzle_08.md))
 - Process input data scaled by `block_id + 1` to create distinct scaling per block
 - Use bounds checking when accessing input data (pattern from [guards in Puzzle 3](../puzzle_03/puzzle_03.md))
 
@@ -153,7 +153,7 @@ block_id = Int(block_idx.x)                          # Block index for reliable 
 
 **Shared memory allocation and data processing:**
 
-- Each block allocates its own shared memory workspace: `tb[dtype]().row_major[tpb]().shared().alloc()`
+- Each block allocates its own shared memory workspace: `LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()`
 - **Scaling strategy**: `data_scale = Float32(block_id + 1)` ensures each block processes data differently
   - Block 0: multiplies by 1.0, Block 1: by 2.0, Block 2: by 3.0, Block 3: by 4.0
 - **Bounds checking**: `if global_i < size:` prevents out-of-bounds memory access

--- a/problems/p08/p08_layout_tensor.mojo
+++ b/problems/p08/p08_layout_tensor.mojo
@@ -1,8 +1,8 @@
 from memory import UnsafePointer
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 
 # ANCHOR: add_10_shared_layout_tensor
@@ -21,8 +21,8 @@ fn add_10_shared_layout_tensor[
     a: LayoutTensor[mut=True, dtype, layout],
     size: Int,
 ):
-    # Allocate shared memory using tensor builder
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    # Allocate shared memory using LayoutTensor with explicit address_space
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/problems/p09/p09.mojo
+++ b/problems/p09/p09.mojo
@@ -1,8 +1,8 @@
 from memory import UnsafePointer
 from gpu import thread_idx, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 from sys import argv
 
@@ -58,7 +58,7 @@ fn collaborative_filter(
     thread_id = thread_idx.x
 
     # Shared memory workspace for collaborative processing
-    shared_workspace = tb[dtype]().row_major[SIZE - 1]().shared().alloc()
+    shared_workspace = LayoutTensor[dtype, Layout.row_major(SIZE - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Phase 1: Initialize shared workspace (all threads participate)
     if thread_id < SIZE - 1:

--- a/problems/p10/p10.mojo
+++ b/problems/p10/p10.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_dim, block_idx, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 from sys import argv
 
@@ -22,7 +22,7 @@ fn shared_memory_race(
     row = thread_idx.y
     col = thread_idx.x
 
-    shared_sum = tb[dtype]().row_major[1]().shared().alloc()
+    shared_sum = LayoutTensor[dtype, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     if row < size and col < size:
         shared_sum[0] += a[row, col]

--- a/problems/p11/p11_layout_tensor.mojo
+++ b/problems/p11/p11_layout_tensor.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 
 # ANCHOR: pooling_layout_tensor
@@ -21,7 +21,7 @@ fn pooling[
     size: Int,
 ):
     # Allocate shared memory using tensor builder
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/problems/p12/p12_layout_tensor.mojo
+++ b/problems/p12/p12_layout_tensor.mojo
@@ -4,7 +4,6 @@ from gpu.host import DeviceContext
 # ANCHOR: dot_product_layout_tensor
 from gpu import thread_idx, block_idx, block_dim, barrier
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 
 
 alias TPB = 8

--- a/problems/p13/p13.mojo
+++ b/problems/p13/p13.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 

--- a/problems/p14/p14.mojo
+++ b/problems/p14/p14.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from math import log2
 from testing import assert_equal

--- a/problems/p15/p15.mojo
+++ b/problems/p15/p15.mojo
@@ -4,8 +4,8 @@ from gpu.host import DeviceContext
 
 # ANCHOR: axis_sum
 from gpu import thread_idx, block_idx, block_dim, barrier
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 
 
 alias TPB = 8

--- a/problems/p16/p16.mojo
+++ b/problems/p16/p16.mojo
@@ -4,8 +4,8 @@ from gpu.host import DeviceContext
 
 # ANCHOR: naive_matmul
 from gpu import thread_idx, block_idx, block_dim, barrier
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 
 
 alias TPB = 3

--- a/problems/p17/op/conv1d.mojo
+++ b/problems/p17/op/conv1d.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 
 # ANCHOR: conv1d_kernel
 alias TPB = 15
@@ -23,8 +23,8 @@ fn conv1d_kernel[
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
     # first: need to account for padding
-    shared_a = tb[dtype]().row_major[TPB + conv_size - 1]().shared().alloc()
-    shared_b = tb[dtype]().row_major[conv_size]().shared().alloc()
+    shared_a = LayoutTensor[dtype, Layout.row_major(TPB + conv_size - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_b = LayoutTensor[dtype, Layout.row_major(conv_size), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < input_size:
         shared_a[local_i] = input[global_i]
 

--- a/problems/p18/op/softmax.mojo
+++ b/problems/p18/op/softmax.mojo
@@ -3,8 +3,8 @@ from memory import UnsafePointer
 # ANCHOR: softmax_gpu_kernel
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext, HostBuffer, DeviceBuffer
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from math import exp
 from bit import log2_ceil
 from utils.numerics import max_finite, min_finite

--- a/problems/p18/test/test_softmax.mojo
+++ b/problems/p18/test/test_softmax.mojo
@@ -1,6 +1,5 @@
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_almost_equal
 from bit import log2_ceil
 

--- a/problems/p20/op/conv1d.mojo
+++ b/problems/p20/op/conv1d.mojo
@@ -1,8 +1,8 @@
 # same as p15/op/conv1d.mojo
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 
@@ -26,8 +26,8 @@ fn conv1d_kernel[
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
     # first: need to account for padding
-    shared_a = tb[dtype]().row_major[TPB + conv_size - 1]().shared().alloc()
-    shared_b = tb[dtype]().row_major[conv_size]().shared().alloc()
+    shared_a = LayoutTensor[dtype, Layout.row_major(TPB + conv_size - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_b = LayoutTensor[dtype, Layout.row_major(conv_size), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < input_size:
         shared_a[local_i] = input[global_i]
 

--- a/problems/p21/op/embedding.mojo
+++ b/problems/p21/op/embedding.mojo
@@ -2,7 +2,6 @@ from math import ceildiv
 from gpu import thread_idx, block_idx, block_dim, grid_dim, barrier
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 

--- a/problems/p22/op/layernorm_linear.mojo
+++ b/problems/p22/op/layernorm_linear.mojo
@@ -1,10 +1,9 @@
 from math import sqrt
 from gpu import thread_idx, block_idx, block_dim, barrier
-from gpu.memory import async_copy_wait_all
+from gpu.memory import AddressSpace, async_copy_wait_all
 from os.atomic import Atomic
 from layout import Layout, LayoutTensor
 from layout.layout_tensor import copy_dram_to_sram_async
-from layout.tensor_builder import LayoutTensorBuild as tb
 import compiler
 from runtime.asyncrt import DeviceContextPtr
 from tensor import InputTensor, OutputTensor
@@ -43,18 +42,8 @@ fn matmul_idiomatic_tiled[
     out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
         block_idx.y, block_idx.x
     )
-    a_shared = (
-        tb[dtype]()
-        .row_major[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY]()
-        .shared()
-        .alloc()
-    )
-    b_shared = (
-        tb[dtype]()
-        .row_major[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY]()
-        .shared()
-        .alloc()
-    )
+    a_shared = LayoutTensor[dtype, Layout.row_major(MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    b_shared = LayoutTensor[dtype, Layout.row_major(MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     var acc: output.element_type = 0
 
     alias load_a_layout = Layout.row_major(
@@ -160,12 +149,7 @@ fn transpose_kernel[
     """Transpose matrix using shared memory tiling for coalesced access.
     We will learn more about coalesced access in the next part.
     """
-    shared_tile = (
-        tb[dtype]()
-        .row_major[TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY]()
-        .shared()
-        .alloc()
-    )
+    shared_tile = LayoutTensor[dtype, Layout.row_major(TRANSPOSE_BLOCK_DIM_XY, TRANSPOSE_BLOCK_DIM_XY), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     local_row = thread_idx.y
     local_col = thread_idx.x

--- a/problems/p23/p23.mojo
+++ b/problems/p23/p23.mojo
@@ -2,7 +2,6 @@ from gpu import thread_idx, block_dim, block_idx, barrier
 from gpu.host import DeviceContext
 from gpu.host.compile import get_gpu_target
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from utils import IndexList
 from math import log2
 from algorithm.functional import elementwise, vectorize

--- a/problems/p24/p24.mojo
+++ b/problems/p24/p24.mojo
@@ -1,10 +1,10 @@
 from math import ceildiv
 from gpu import thread_idx, block_idx, block_dim, barrier, lane_id
 from gpu.host import DeviceContext, HostBuffer, DeviceBuffer
+from gpu.memory import AddressSpace
 from gpu.warp import sum as warp_sum, WARP_SIZE
 from algorithm.functional import elementwise
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from utils import IndexList
 from sys import argv, simd_width_of, size_of, align_of
 from testing import assert_equal
@@ -41,7 +41,7 @@ fn traditional_dot_product_p12_style[
     """
     This is the complex approach from p12_layout_tensor.mojo - kept for comparison.
     """
-    shared = tb[dtype]().row_major[WARP_SIZE]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(WARP_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
 

--- a/problems/p27/p27.mojo
+++ b/problems/p27/p27.mojo
@@ -3,8 +3,8 @@ from os.atomic import Atomic
 from gpu.warp import WARP_SIZE
 from gpu import block
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_equal
 from math import floor
@@ -21,7 +21,7 @@ fn traditional_dot_product[
     """Traditional dot product using shared memory + barriers + tree reduction.
     Educational but complex - shows the manual coordination needed."""
 
-    shared = tb[dtype]().row_major[tpb]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
 

--- a/problems/p28/p28.mojo
+++ b/problems/p28/p28.mojo
@@ -1,8 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, grid_dim, barrier
 from gpu.host import DeviceContext
-from gpu.memory import async_copy_wait_all
+from gpu.memory import AddressSpace, async_copy_wait_all
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from layout.layout_tensor import copy_dram_to_sram_async
 from sys import argv, info
 from testing import assert_equal, assert_almost_equal
@@ -35,8 +34,8 @@ fn async_copy_overlap_convolution[
     """
 
     # Shared memory buffers (like p14, but without .fill(0) to avoid race)
-    input_shared = tb[dtype]().row_major[CONV_TILE_SIZE]().shared().alloc()
-    kernel_shared = tb[dtype]().row_major[KERNEL_SIZE]().shared().alloc()
+    input_shared = LayoutTensor[dtype, Layout.row_major(CONV_TILE_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    kernel_shared = LayoutTensor[dtype, Layout.row_major(KERNEL_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # FILL IN HERE (roughly 19 lines)
 

--- a/problems/p29/p29.mojo
+++ b/problems/p29/p29.mojo
@@ -8,9 +8,8 @@ from gpu.sync import (
     cp_async_bulk_wait_group,
 )
 from gpu.host import DeviceContext
-from gpu.memory import async_copy_wait_all
+from gpu.memory import AddressSpace, async_copy_wait_all
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from layout.layout_tensor import copy_dram_to_sram_async
 from sys import size_of, argv, info
 from testing import assert_true, assert_almost_equal
@@ -45,8 +44,8 @@ fn multi_stage_image_blur_pipeline[
     """
 
     # Shared memory buffers for pipeline stages
-    input_shared = tb[dtype]().row_major[TPB]().shared().alloc()
-    blur_shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    input_shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    blur_shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
@@ -93,13 +92,13 @@ fn double_buffered_stencil_computation[
     """
 
     # Double-buffering: Two shared memory buffers
-    buffer_A = tb[dtype]().row_major[TPB]().shared().alloc()
-    buffer_B = tb[dtype]().row_major[TPB]().shared().alloc()
+    buffer_A = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    buffer_B = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Memory barriers for coordinating buffer swaps
-    init_barrier = tb[DType.uint64]().row_major[1]().shared().alloc()
-    iter_barrier = tb[DType.uint64]().row_major[1]().shared().alloc()
-    final_barrier = tb[DType.uint64]().row_major[1]().shared().alloc()
+    init_barrier = LayoutTensor[DType.uint64, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    iter_barrier = LayoutTensor[DType.uint64, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    final_barrier = LayoutTensor[DType.uint64, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/problems/p30/p30.mojo
+++ b/problems/p30/p30.mojo
@@ -1,7 +1,6 @@
 from gpu import thread_idx, block_dim, block_idx
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_almost_equal
 from benchmark import Bench, BenchConfig, Bencher, BenchId, keep

--- a/problems/p31/p31.mojo
+++ b/problems/p31/p31.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_dim, block_idx, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_almost_equal
 from benchmark import Bench, BenchConfig, Bencher, BenchId, keep
@@ -46,7 +46,7 @@ fn sophisticated_kernel[
     """Sophisticated SAXPY kernel - over-engineered with excessive resource usage.
     """
     # Maximum shared memory allocation (close to 48KB limit)
-    shared_cache = tb[dtype]().row_major[1024 * 12]().shared().alloc()  # 48KB
+    shared_cache = LayoutTensor[dtype, Layout.row_major(1024 * 12), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()  # 48KB
 
     i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
@@ -138,9 +138,7 @@ fn balanced_kernel[
     """Balanced SAXPY kernel - efficient optimization with moderate resources.
     """
     # Reasonable shared memory usage for effective caching (16KB)
-    shared_cache = (
-        tb[dtype]().row_major[1024 * 4]().shared().alloc()
-    )  # 16KB total
+    shared_cache = LayoutTensor[dtype, Layout.row_major(1024 * 4), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()  # 16KB total
 
     i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/problems/p32/p32.mojo
+++ b/problems/p32/p32.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_dim, block_idx, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_almost_equal
 from benchmark import Bench, BenchConfig, Bencher, BenchId, keep
@@ -29,7 +29,7 @@ fn no_conflict_kernel[
     """
 
     # Shared memory buffer - each thread loads one element
-    shared_buf = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared_buf = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
@@ -67,7 +67,7 @@ fn two_way_conflict_kernel[
     """
 
     # Shared memory buffer - stride-2 access pattern creates conflicts
-    shared_buf = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared_buf = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/problems/p33/p33.mojo
+++ b/problems/p33/p33.mojo
@@ -1,10 +1,9 @@
 from gpu import thread_idx, block_idx, block_dim, barrier, WARP_SIZE
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace, async_copy_wait_all
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from layout.tensor_core import TensorCore
 from layout.layout_tensor import copy_dram_to_sram_async
-from gpu.memory import async_copy_wait_all
 from utils import Index
 from sys import size_of, argv
 from testing import assert_equal, assert_almost_equal
@@ -41,8 +40,8 @@ fn matmul_idiomatic_tiled[
 
     # Get the tile of the output matrix that this thread block is responsible for
     out_tile = output.tile[TILE_SIZE, TILE_SIZE](block_idx.y, block_idx.x)
-    a_shared = tb[dtype]().row_major[TILE_SIZE, TILE_SIZE]().shared().alloc()
-    b_shared = tb[dtype]().row_major[TILE_SIZE, TILE_SIZE]().shared().alloc()
+    a_shared = LayoutTensor[dtype, Layout.row_major(TILE_SIZE, TILE_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    b_shared = LayoutTensor[dtype, Layout.row_major(TILE_SIZE, TILE_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     var acc: output.element_type = 0
 
@@ -146,11 +145,11 @@ fn tensor_core_matrix_multiplication[
     mma_op = TensorCore[A.dtype, C.dtype, Index(MMA_M, MMA_N, MMA_K)]()
 
     # Shared SRAM tiles (no padding to stay under shared memory limit)
-    A_sram_tile = tb[A.dtype]().row_major[BM, BK]().shared().alloc()
-    B_sram_tile = tb[B.dtype]().row_major[BK, BN]().shared().alloc()
+    A_sram_tile = LayoutTensor[A.dtype, Layout.row_major(BM, BK), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    B_sram_tile = LayoutTensor[B.dtype, Layout.row_major(BK, BN), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # One per-warp accumulator tile of shape [WM, WN]
-    C_warp_accum = tb[C.dtype]().row_major[WM, WN]().local().alloc()
+    C_warp_accum = LayoutTensor[C.dtype, Layout.row_major(WM, WN), MutableAnyOrigin, address_space = AddressSpace.GENERIC].stack_allocation()
 
     # Zero initialize accumulator (only for active warps)
     if warp_is_active:

--- a/problems/p34/p34.mojo
+++ b/problems/p34/p34.mojo
@@ -8,8 +8,8 @@ from gpu.cluster import (
     cluster_mask_base,
     elect_one_sync,
 )
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_equal, assert_almost_equal, assert_true
 
@@ -37,7 +37,7 @@ fn cluster_coordination_basics[
     my_block_rank = Int(block_rank_in_cluster())
     block_id = Int(block_idx.x)
 
-    shared_data = tb[dtype]().row_major[tpb]().shared().alloc()
+    shared_data = LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # FIX: Use block_idx.x for data distribution instead of cluster rank
     # Each block should process different portions of the data

--- a/solutions/p08/p08_layout_tensor.mojo
+++ b/solutions/p08/p08_layout_tensor.mojo
@@ -1,8 +1,8 @@
 from memory import UnsafePointer
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 
 alias TPB = 4
@@ -22,7 +22,7 @@ fn add_10_shared_layout_tensor[
     size: Int,
 ):
     # Allocate shared memory using tensor builder
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/solutions/p10/p10.mojo
+++ b/solutions/p10/p10.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_dim, block_idx, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 from sys import argv
 from os.atomic import Atomic
@@ -24,7 +24,7 @@ fn shared_memory_race(
     row = thread_idx.y
     col = thread_idx.x
 
-    shared_sum = tb[dtype]().row_major[1]().shared().alloc()
+    shared_sum = LayoutTensor[dtype, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Only thread 0 does all the accumulation work to prevent races
     if row == 0 and col == 0:

--- a/solutions/p11/p11_layout_tensor.mojo
+++ b/solutions/p11/p11_layout_tensor.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 
 alias TPB = 8
@@ -21,7 +21,7 @@ fn pooling[
     size: Int,
 ):
     # Allocate shared memory using tensor builder
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/solutions/p12/p12_layout_tensor.mojo
+++ b/solutions/p12/p12_layout_tensor.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_equal
 
 alias TPB = 8
@@ -22,7 +22,7 @@ fn dot_product[
     b: LayoutTensor[mut=True, dtype, in_layout],
     size: Int,
 ):
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
 

--- a/solutions/p13/p13.mojo
+++ b/solutions/p13/p13.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 
@@ -26,8 +26,8 @@ fn conv_1d_simple[
 ):
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
-    shared_a = tb[dtype]().row_major[SIZE]().shared().alloc()
-    shared_b = tb[dtype]().row_major[CONV]().shared().alloc()
+    shared_a = LayoutTensor[dtype, Layout.row_major(SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_b = LayoutTensor[dtype, Layout.row_major(CONV), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < SIZE:
         shared_a[local_i] = a[global_i]
 
@@ -84,8 +84,8 @@ fn conv_1d_block_boundary[
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
     # first: need to account for padding
-    shared_a = tb[dtype]().row_major[TPB + CONV_2 - 1]().shared().alloc()
-    shared_b = tb[dtype]().row_major[CONV_2]().shared().alloc()
+    shared_a = LayoutTensor[dtype, Layout.row_major(TPB + CONV_2 - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_b = LayoutTensor[dtype, Layout.row_major(CONV_2), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < SIZE_2:
         shared_a[local_i] = a[global_i]
     else:

--- a/solutions/p14/p14.mojo
+++ b/solutions/p14/p14.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from math import log2
 from testing import assert_equal
@@ -24,7 +24,7 @@ fn prefix_sum_simple[
 ):
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < size:
         shared[local_i] = a[global_i]
 
@@ -69,7 +69,7 @@ fn prefix_sum_local_phase[
 ):
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
-    shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Load data into shared memory
     # Example with SIZE_2=15, TPB=8, BLOCKS=2:

--- a/solutions/p15/p15.mojo
+++ b/solutions/p15/p15.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of
 from testing import assert_equal
 
@@ -26,7 +26,7 @@ fn axis_sum[
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
     batch = block_idx.y
-    cache = tb[dtype]().row_major[TPB]().shared().alloc()
+    cache = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Visualize:
     # Block(0,0): [T0,T1,T2,T3,T4,T5,T6,T7] -> Row 0: [0,1,2,3,4,5]

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 
@@ -50,8 +50,8 @@ fn single_block_matmul[
     local_row = thread_idx.y
     local_col = thread_idx.x
 
-    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
-    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
+    a_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    b_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     if row < size and col < size:
         a_shared[local_row, local_col] = a[row, col]
@@ -91,8 +91,8 @@ fn matmul_tiled[
     tiled_row = block_idx.y * TPB + local_row
     tiled_col = block_idx.x * TPB + local_col
 
-    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
-    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
+    a_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    b_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     var acc: output.element_type = 0
 
@@ -151,8 +151,8 @@ fn matmul_idiomatic_tiled[
 
     # Get the tile of the output matrix that this thread block is responsible for
     out_tile = output.tile[TPB, TPB](block_idx.y, block_idx.x)
-    a_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
-    b_shared = tb[dtype]().row_major[TPB, TPB]().shared().alloc()
+    a_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    b_shared = LayoutTensor[dtype, Layout.row_major(TPB, TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     var acc: output.element_type = 0
 

--- a/solutions/p17/op/conv1d.mojo
+++ b/solutions/p17/op/conv1d.mojo
@@ -1,7 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 
@@ -24,8 +24,8 @@ fn conv1d_kernel[
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
     # first: need to account for padding
-    shared_a = tb[dtype]().row_major[TPB + conv_size - 1]().shared().alloc()
-    shared_b = tb[dtype]().row_major[conv_size]().shared().alloc()
+    shared_a = LayoutTensor[dtype, Layout.row_major(TPB + conv_size - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_b = LayoutTensor[dtype, Layout.row_major(conv_size), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < input_size:
         shared_a[local_i] = input[global_i]
 

--- a/solutions/p18/op/softmax.mojo
+++ b/solutions/p18/op/softmax.mojo
@@ -1,8 +1,8 @@
 from memory import UnsafePointer
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext, HostBuffer, DeviceBuffer
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from math import exp
 from bit import log2_ceil
 from utils.numerics import max_finite, min_finite
@@ -24,8 +24,8 @@ fn softmax_gpu_kernel[
     output: LayoutTensor[mut=True, dtype, layout],
     input: LayoutTensor[mut=False, dtype, layout],
 ):
-    shared_max = tb[dtype]().row_major[BLOCK_DIM_X]().shared().alloc()
-    shared_sum = tb[dtype]().row_major[BLOCK_DIM_X]().shared().alloc()
+    shared_max = LayoutTensor[dtype, Layout.row_major(BLOCK_DIM_X), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_sum = LayoutTensor[dtype, Layout.row_major(BLOCK_DIM_X), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     global_i = thread_idx.x
 
     # Initialize out-of-bounds (shared_max[local_i], global_i >= input_size) shared memory addresses to the minimum

--- a/solutions/p18/test/test_softmax.mojo
+++ b/solutions/p18/test/test_softmax.mojo
@@ -1,6 +1,5 @@
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from testing import assert_almost_equal
 from bit import log2_ceil
 

--- a/solutions/p20/op/conv1d.mojo
+++ b/solutions/p20/op/conv1d.mojo
@@ -1,8 +1,8 @@
 # same as p15/op/conv1d.mojo
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 
@@ -25,8 +25,8 @@ fn conv1d_kernel[
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
     # first: need to account for padding
-    shared_a = tb[dtype]().row_major[TPB + conv_size - 1]().shared().alloc()
-    shared_b = tb[dtype]().row_major[conv_size]().shared().alloc()
+    shared_a = LayoutTensor[dtype, Layout.row_major(TPB + conv_size - 1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    shared_b = LayoutTensor[dtype, Layout.row_major(conv_size), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     if global_i < input_size:
         shared_a[local_i] = input[global_i]
 

--- a/solutions/p21/op/embedding.mojo
+++ b/solutions/p21/op/embedding.mojo
@@ -2,7 +2,6 @@ from math import ceildiv
 from gpu import thread_idx, block_idx, block_dim, grid_dim, barrier
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import size_of, argv
 from testing import assert_equal
 

--- a/solutions/p23/p23.mojo
+++ b/solutions/p23/p23.mojo
@@ -2,7 +2,6 @@ from gpu import thread_idx, block_dim, block_idx, barrier
 from gpu.host import DeviceContext
 from gpu.host.compile import get_gpu_target
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from utils import IndexList
 from math import log2
 from algorithm.functional import elementwise, vectorize

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -2,9 +2,9 @@ from math import ceildiv
 from gpu import thread_idx, block_idx, block_dim, barrier, lane_id
 from gpu.host import DeviceContext, HostBuffer, DeviceBuffer
 from gpu.warp import sum as warp_sum, WARP_SIZE
+from gpu.memory import AddressSpace
 from algorithm.functional import elementwise
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from utils import IndexList
 from sys import argv, simd_width_of, size_of, align_of
 from testing import assert_equal
@@ -41,7 +41,7 @@ fn traditional_dot_product_p12_style[
     """
     This is the complex approach from p12_layout_tensor.mojo - kept for comparison.
     """
-    shared = tb[dtype]().row_major[WARP_SIZE]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(WARP_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
 

--- a/solutions/p27/p27.mojo
+++ b/solutions/p27/p27.mojo
@@ -3,8 +3,8 @@ from os.atomic import Atomic
 from gpu.warp import WARP_SIZE
 from gpu import block
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_equal
 from math import floor
@@ -64,7 +64,7 @@ fn traditional_dot_product[
     """Traditional dot product using shared memory + barriers + tree reduction.
     Educational but complex - shows the manual coordination needed."""
 
-    shared = tb[dtype]().row_major[tpb]().shared().alloc()
+    shared = LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
 

--- a/solutions/p28/p28.mojo
+++ b/solutions/p28/p28.mojo
@@ -1,8 +1,7 @@
 from gpu import thread_idx, block_idx, block_dim, grid_dim, barrier
 from gpu.host import DeviceContext
-from gpu.memory import async_copy_wait_all
+from gpu.memory import async_copy_wait_all, AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from layout.layout_tensor import copy_dram_to_sram_async
 from sys import argv, info
 from testing import assert_equal, assert_almost_equal
@@ -36,8 +35,8 @@ fn async_copy_overlap_convolution[
     """
 
     # Shared memory buffers (like p14, but without .fill(0) to avoid race)
-    input_shared = tb[dtype]().row_major[CONV_TILE_SIZE]().shared().alloc()
-    kernel_shared = tb[dtype]().row_major[KERNEL_SIZE]().shared().alloc()
+    input_shared = LayoutTensor[dtype, Layout.row_major(CONV_TILE_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    kernel_shared = LayoutTensor[dtype, Layout.row_major(KERNEL_SIZE), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     local_i = thread_idx.x
 

--- a/solutions/p29/p29.mojo
+++ b/solutions/p29/p29.mojo
@@ -5,8 +5,8 @@ from gpu.sync import (
     mbarrier_test_wait,
 )
 from gpu.host import DeviceContext
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from layout.layout_tensor import copy_dram_to_sram_async
 from sys import size_of, argv, info
 from testing import assert_true, assert_almost_equal
@@ -40,8 +40,8 @@ fn multi_stage_image_blur_pipeline[
     """
 
     # Shared memory buffers for pipeline stages
-    input_shared = tb[dtype]().row_major[TPB]().shared().alloc()
-    blur_shared = tb[dtype]().row_major[TPB]().shared().alloc()
+    input_shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    blur_shared = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x
@@ -137,13 +137,13 @@ fn double_buffered_stencil_computation[
     """
 
     # Double-buffering: Two shared memory buffers
-    buffer_A = tb[dtype]().row_major[TPB]().shared().alloc()
-    buffer_B = tb[dtype]().row_major[TPB]().shared().alloc()
+    buffer_A = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    buffer_B = LayoutTensor[dtype, Layout.row_major(TPB), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Memory barriers for coordinating buffer swaps
-    init_barrier = tb[DType.uint64]().row_major[1]().shared().alloc()
-    iter_barrier = tb[DType.uint64]().row_major[1]().shared().alloc()
-    final_barrier = tb[DType.uint64]().row_major[1]().shared().alloc()
+    init_barrier = LayoutTensor[DType.uint64, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    iter_barrier = LayoutTensor[DType.uint64, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
+    final_barrier = LayoutTensor[DType.uint64, Layout.row_major(1), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     global_i = block_dim.x * block_idx.x + thread_idx.x
     local_i = thread_idx.x

--- a/solutions/p34/p34.mojo
+++ b/solutions/p34/p34.mojo
@@ -8,8 +8,8 @@ from gpu.cluster import (
     cluster_mask_base,
     elect_one_sync,
 )
+from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from layout.tensor_builder import LayoutTensorBuild as tb
 from sys import argv
 from testing import assert_equal, assert_almost_equal, assert_true
 
@@ -37,7 +37,7 @@ fn cluster_coordination_basics[
     my_block_rank = Int(block_rank_in_cluster())
     block_id = Int(block_idx.x)
 
-    shared_data = tb[dtype]().row_major[tpb]().shared().alloc()
+    shared_data = LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # FIX: Use block_idx.x for data distribution instead of cluster rank
     # Each block should process different portions of the data
@@ -92,7 +92,7 @@ fn cluster_collective_operations[
         my_value = input[global_i][0]
 
     # Block-level reduction using shared memory
-    shared_mem = tb[dtype]().row_major[tpb]().shared().alloc()
+    shared_mem = LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
     shared_mem[local_i] = my_value
     barrier()
 
@@ -137,7 +137,7 @@ fn advanced_cluster_patterns[
     my_block_rank = Int(block_rank_in_cluster())
     block_id = Int(block_idx.x)
 
-    shared_data = tb[dtype]().row_major[tpb]().shared().alloc()
+    shared_data = LayoutTensor[dtype, Layout.row_major(tpb), MutableAnyOrigin, address_space = AddressSpace.SHARED].stack_allocation()
 
     # Compute cluster mask for advanced coordination
     # base_mask = cluster_mask_base()  # Requires cluster_shape parameter


### PR DESCRIPTION
* Update all problem files (p08-p34) to use new LayoutTensor API
* Update all solution files to use LayoutTensor with address_space parameter
* Replace deprecated LayoutTensorBuild.shared().alloc() pattern
* Use AddressSpace.SHARED for shared memory allocations
* Update documentation to reflect new API usage
* Remove obsolete LayoutTensorBuild imports across codebase

This change aligns with the Modular deprecation of LayoutTensorBuild (See https://github.com/modular/modular/commit/d4e10a2afd6aff9b0f55092cbab0d65aaa44e8a2) in favor of LayoutTensor with explicit address_space