### PR TITLE
Fix argv length constraint for p13.mojo

### DIFF
--- a/problems/p13/p13.mojo
+++ b/problems/p13/p13.mojo
@@ -71,7 +71,7 @@ def main():
             for i in range(conv):
                 b_host[i] = i
 
-        if len(argv()) != 2 or argv()[1] not in [
+        if len(argv()) < 2 or argv()[1] not in [
             "--simple",
             "--block-boundary",
         ]:


### PR DESCRIPTION
The `len(argv()) != 2` constraint does not work for systems other than the default.

When running `pixi run p13 --simple -e apple` for example, it raises an exception because -e and apple make the `len(argv)` greater than 2