### PR TITLE
Mobile breakpoint nav overlap

### DIFF
--- a/book/theme/css/custom.css
+++ b/book/theme/css/custom.css
@@ -814,9 +814,6 @@ mark {
   :root {
     --sidebar-width: 100vw;
   }
-  .sidebar {
-    width: 100vw;
-  }
 }
 
 /* Hide theme selection menu */


### PR DESCRIPTION
### Summary
This PR attempts to fix this issue: https://linear.app/modularml/issue/DESN-1062/on-mobile-the-nav-overlaps-the-page

The issue was difficult to replicate locally, likely due to some type of css caching/minified styling with different specificity - but inspecting the code in production, I noticed that the width of the sidebar is being referenced as a root variable *first*. So I think adding a root variable override at a smaller breakpoint is a sensible approach to try to fix the bug. 

