### PR TITLE
Fix use of deprecated pixi syntax

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 authors = ["Modular <hello@modular.com>"]
 channels = ["https://conda.modular.com/max-nightly", "conda-forge"]
 name = "mojo-gpu-puzzles"


### PR DESCRIPTION
Replaced the use of [project] with [workspace]. The former was deprecated in https://pixi.sh/dev/CHANGELOG/#0570-2025-10-20