### PR TITLE
Fail p03 when no bounds checking is used

### DIFF
--- a/problems/p03/p03.mojo
+++ b/problems/p03/p03.mojo
@@ -5,8 +5,9 @@ from testing import assert_equal
 
 # ANCHOR: add_10_guard
 alias SIZE = 4
+alias CHECKED_SIZE = 8
 alias BLOCKS_PER_GRID = 1
-alias THREADS_PER_BLOCK = (8, 1)
+alias THREADS_PER_BLOCK = 8
 alias dtype = DType.float32
 
 
@@ -24,7 +25,7 @@ fn add_10_guard(
 
 def main():
     with DeviceContext() as ctx:
-        out = ctx.enqueue_create_buffer[dtype](SIZE).enqueue_fill(0)
+        out = ctx.enqueue_create_buffer[dtype](CHECKED_SIZE).enqueue_fill(0)
         a = ctx.enqueue_create_buffer[dtype](SIZE).enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
@@ -38,7 +39,9 @@ def main():
             block_dim=THREADS_PER_BLOCK,
         )
 
-        expected = ctx.enqueue_create_host_buffer[dtype](SIZE).enqueue_fill(0)
+        expected = ctx.enqueue_create_host_buffer[dtype](
+            CHECKED_SIZE
+        ).enqueue_fill(0)
         ctx.synchronize()
 
         for i in range(SIZE):
@@ -47,5 +50,5 @@ def main():
         with out.map_to_host() as out_host:
             print("out:", out_host)
             print("expected:", expected)
-            for i in range(SIZE):
+            for i in range(CHECKED_SIZE):
                 assert_equal(out_host[i], expected[i])


### PR DESCRIPTION
When running p03 on macos the check passes even with an incorrect kernel.
```
    # FILL ME IN (roughly 2 lines)
    output[i] = a[i] + 10
```

```
(mojo-gpu-puzzles) chill@Mareks-Laptop mojo-gpu-puzzles % pixi run p03
✨ Pixi task (p03 in default): mojo problems/p03/p03.mojo                                                                                                  
out: HostBuffer([10.0, 11.0, 12.0, 13.0])
expected: HostBuffer([10.0, 11.0, 12.0, 13.0])
```

This PR catches the mistake by using a bigger array.

```
(mojo-gpu-puzzles) chill@Mareks-Laptop mojo-gpu-puzzles % pixi run p03              
✨ Pixi task (p03 in default): mojo problems/p03/p03.mojo                                                                                                  
out: HostBuffer([10.0, 11.0, 12.0, 13.0, 10.0, 10.0, 10.0, 10.0])
expected: HostBuffer([10.0, 11.0, 12.0, 13.0, 0.0, 0.0, 0.0, 0.0])
stack trace was not collected. Enable stack trace collection with environment variable `MOJO_ENABLE_STACK_TRACE_ON_ERROR`
Unhandled exception caught during execution: At /Users/chill/Documents/GitHub/mojo-gpu-puzzles/problems/p03/p03.mojo:55:29: AssertionError: `left == right` comparison failed:
   left: 10.0
  right: 0.0
```

- The incorrect kernel might have a UB, so this is just a best effort check to protect against that.
- This might need additional discussion in the puzzle text itself to make the distinction between thread count and array size clearer.
- Another approach would be to tell the user they likely forgot to check the bounds but hide the bigger array from them.
- Once some form of this PR is accepted I'd be happy to apply it also to other puzzles that suffer from the same problem.