### PR TITLE
Update documentation for the next batch of enabled puzzles on Apple silicon GPU

### DIFF
--- a/book/src/howto.md
+++ b/book/src/howto.md
@@ -256,7 +256,7 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 | 15 - Matmul | ✅ | ✅ | ✅ | Basic GPU kernels |
 | 16 - Flashdot | ✅ | ✅ | ❌ | Advanced memory patterns |
 | **Part IV: MAX Graph** | | | | |
-| 17 - Custom Op | ✅ | ✅ | ❌ | MAX Graph integration |
+| 17 - Custom Op | ✅ | ✅ | ✅ | MAX Graph integration |
 | 18 - Softmax | ✅ | ✅ | ✅ | MAX Graph integration |
 | 19 - Attention | ✅ | ✅ | ❌ | MAX Graph integration |
 | **Part V: PyTorch Integration** | | | | |
@@ -266,11 +266,11 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 | **Part VI: Functional Patterns** | | | | |
 | 23 - Functional | ✅ | ✅ | ✅ | Advanced Mojo patterns |
 | **Part VII: Warp Programming** | | | | |
-| 24 - Warp Sum | ✅ | ✅ | ❌ | Warp-level operations |
-| 25 - Warp Communication | ✅ | ✅ | ❌ | Warp-level operations |
-| 26 - Advanced Warp | ✅ | ✅ | ❌ | Warp-level operations |
+| 24 - Warp Sum | ✅ | ✅ | ✅ | Warp-level operations |
+| 25 - Warp Communication | ✅ | ✅ | ✅ | Warp-level operations |
+| 26 - Advanced Warp | ✅ | ✅ | ✅ | Warp-level operations |
 | **Part VIII: Block Programming** | | | | |
-| 27 - Block Operations | ✅ | ✅ | ❌ | Block-level patterns |
+| 27 - Block Operations | ✅ | ✅ | ✅ | Block-level patterns |
 | **Part IX: Memory Systems** | | | | |
 | 28 - Async Memory | ✅ | ✅ | ❌ | Advanced memory operations |
 | 29 - Barriers | ✅ | ✅ | ❌ | Advanced synchronization |
@@ -303,7 +303,7 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 
 **Apple GPUs (Basic Support)**
 
-- Only fundamental puzzles (1-8, 11-15, 18, 23) supported
+- A selection of fundamental (1-8, 11-18) and advanced (23-27) puzzles are supported
 - Missing: All advanced features, debugging, profiling tools
 - Suitable for learning basic GPU programming patterns
 

--- a/book/src/puzzle_17/puzzle_17.md
+++ b/book/src/puzzle_17/puzzle_17.md
@@ -54,6 +54,7 @@ You can run the puzzle with:
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -67,6 +68,13 @@ pixi run p17
 
 ```bash
 pixi run -e amd p17
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p17
 ```
 
   </div>

--- a/book/src/puzzle_24/warp_sum.md
+++ b/book/src/puzzle_24/warp_sum.md
@@ -49,6 +49,7 @@ This works, but it's verbose, error-prone, and requires deep understanding of GP
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -62,6 +63,13 @@ pixi run p24 --traditional
 
 ```bash
 pixi run -e amd p24 --traditional
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p24 --traditional
 ```
 
   </div>

--- a/book/src/puzzle_25/warp_broadcast.md
+++ b/book/src/puzzle_25/warp_broadcast.md
@@ -144,6 +144,7 @@ After broadcasting, all lanes have the same value and can use it in their indivi
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -157,6 +158,13 @@ pixi run p25 --broadcast-basic
 
 ```bash
 pixi run -e amd p25 --broadcast-basic
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p25 --broadcast-basic
 ```
 
   </div>

--- a/book/src/puzzle_25/warp_shuffle_down.md
+++ b/book/src/puzzle_25/warp_shuffle_down.md
@@ -132,6 +132,7 @@ lane = lane_id()  # Returns 0 to WARP_SIZE-1
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -145,6 +146,13 @@ pixi run p25 --neighbor
 
 ```bash
 pixi run -e amd p25 --neighbor
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p25 --neighbor
 ```
 
   </div>

--- a/book/src/puzzle_26/warp_prefix_sum.md
+++ b/book/src/puzzle_26/warp_prefix_sum.md
@@ -119,6 +119,7 @@ The `prefix_sum` function may require specific data types for optimal performanc
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -132,6 +133,13 @@ pixi run p26 --prefix-sum
 
 ```bash
 pixi run -e amd p26 --prefix-sum
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p26 --prefix-sum
 ```
 
   </div>

--- a/book/src/puzzle_26/warp_shuffle_xor.md
+++ b/book/src/puzzle_26/warp_shuffle_xor.md
@@ -126,6 +126,7 @@ Unlike `shuffle_down()`, `shuffle_xor()` operations stay within warp boundaries.
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -139,6 +140,13 @@ pixi run p26 --pair-swap
 
 ```bash
 pixi run -e amd p26 --pair-swap
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p26 --pair-swap
 ```
 
   </div>

--- a/book/src/puzzle_27/block_broadcast.md
+++ b/book/src/puzzle_27/block_broadcast.md
@@ -182,6 +182,7 @@ The beauty is that each block operation follows consistent patterns!
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -195,6 +196,13 @@ pixi run p27 --normalize
 
 ```bash
 pixi run -e amd p27 --normalize
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p27 --normalize
 ```
 
   </div>

--- a/book/src/puzzle_27/block_prefix_sum.md
+++ b/book/src/puzzle_27/block_prefix_sum.md
@@ -162,6 +162,7 @@ Remember the patterns from previous puzzles:
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -175,6 +176,13 @@ pixi run p27 --histogram
 
 ```bash
 pixi run -e amd p27 --histogram
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p27 --histogram
 ```
 
   </div>

--- a/book/src/puzzle_27/block_sum.md
+++ b/book/src/puzzle_27/block_sum.md
@@ -68,6 +68,7 @@ Before jumping to block-level operations, recall how [Puzzle 24](../puzzle_24/wa
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -81,6 +82,13 @@ pixi run p27 --traditional-dot-product
 
 ```bash
 pixi run -e amd p27 --traditional-dot-product
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p27 --traditional-dot-product
 ```
 
   </div>

--- a/problems/p17/p17.py
+++ b/problems/p17/p17.py
@@ -81,8 +81,8 @@ if __name__ == "__main__":
     INPUT_SIZE = 15
     KERNEL_SIZE = 4
 
-    # Place the graph on a GPU if available, otherwise use CPU
-    device = CPU() if accelerator_count() == 0 else Accelerator()
+    # Place the graph on a GPU
+    device = Accelerator()
 
     # Set up an inference session for running the graph
     session = InferenceSession(devices=[device])

--- a/solutions/p17/p17.py
+++ b/solutions/p17/p17.py
@@ -81,8 +81,8 @@ if __name__ == "__main__":
     INPUT_SIZE = 15
     KERNEL_SIZE = 4
 
-    # Place the graph on a GPU if available, otherwise use CPU
-    device = CPU() if accelerator_count() == 0 else Accelerator()
+    # Place the graph on a GPU
+    device = Accelerator()
 
     # Set up an inference session for running the graph
     session = InferenceSession(devices=[device])


### PR DESCRIPTION
With recent fixes, four more puzzles are now operational on Apple silicon GPU (24-27).

Additionally, puzzle 17 is now operational on Apple silicon GPUs if you don't check for `accelerator_count()` (on Apple silicon, `accelerator_count()` artificially returns 0 today to prevent other failures). Since these puzzles assume the presence of a GPU, it's safe to remove the `accelerator_count()` fallback in this puzzle since a user would have hit accelerator-related errors earlier in the process.