### PR TITLE
Update code to use new UnsafePointer

### DIFF
--- a/book/src/puzzle_09/first_case.md
+++ b/book/src/puzzle_09/first_case.md
@@ -149,12 +149,12 @@ Cannot access memory at address 0x0
 **The Problem**: Now if we look at the [code](../../../problems/p09/p09.mojo) for `--first-crash`, we see that the host code creates a null pointer instead of allocating proper GPU memory:
 
 ```mojo
-input_ptr = UnsafePointer[Scalar[dtype]]()  # Creates NULL pointer!
+input_ptr = {}  # Creates NULL pointer!
 ```
 
 **Why This Crashes**:
 
-1. `UnsafePointer[Scalar[dtype]]()` creates an uninitialized pointer (null)
+1. `{}` creates an uninitialized pointer (null)
 2. This null pointer gets passed to the GPU kernel
 3. When kernel tries `input[i]`, it dereferences null → `CUDA_ERROR_ILLEGAL_ADDRESS`
 
@@ -164,7 +164,7 @@ Replace null pointer creation with proper buffer allocation:
 
 ```mojo
 # Wrong: Creates null pointer
-input_ptr = UnsafePointer[Scalar[dtype]]()
+input_ptr = {}
 
 # Correct: Allocates and initialize actual GPU memory for safe processing
 input_buf = ctx.enqueue_create_buffer[dtype](SIZE)

--- a/problems/p01/p01.mojo
+++ b/problems/p01/p01.mojo
@@ -1,4 +1,3 @@
-from memory import UnsafePointer
 from gpu import thread_idx
 from gpu.host import DeviceContext
 from testing import assert_equal
@@ -11,7 +10,8 @@ alias dtype = DType.float32
 
 
 fn add_10(
-    output: UnsafePointer[Scalar[dtype]], a: UnsafePointer[Scalar[dtype]]
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     i = thread_idx.x
     # FILL ME IN (roughly 1 line)

--- a/problems/p02/p02.mojo
+++ b/problems/p02/p02.mojo
@@ -11,9 +11,9 @@ alias dtype = DType.float32
 
 
 fn add(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
-    b: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     i = thread_idx.x
     # FILL ME IN (roughly 1 line)

--- a/problems/p03/p03.mojo
+++ b/problems/p03/p03.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 
 fn add_10_guard(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     i = thread_idx.x

--- a/problems/p04/p04.mojo
+++ b/problems/p04/p04.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 
 fn add_10_2d(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     row = thread_idx.y

--- a/problems/p05/p05.mojo
+++ b/problems/p05/p05.mojo
@@ -11,9 +11,9 @@ alias dtype = DType.float32
 
 
 fn broadcast_add(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
-    b: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     row = thread_idx.y

--- a/problems/p06/p06.mojo
+++ b/problems/p06/p06.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 
 fn add_10_blocks(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     i = block_dim.x * block_idx.x + thread_idx.x

--- a/problems/p07/p07.mojo
+++ b/problems/p07/p07.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 
 fn add_10_blocks_2d(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     row = block_dim.y * block_idx.y + thread_idx.y

--- a/problems/p08/p08.mojo
+++ b/problems/p08/p08.mojo
@@ -14,8 +14,8 @@ alias dtype = DType.float32
 
 
 fn add_10_shared(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     shared = stack_allocation[

--- a/problems/p09/p09.mojo
+++ b/problems/p09/p09.mojo
@@ -17,7 +17,8 @@ alias ITER = 2
 
 # ANCHOR: first_crash
 fn add_10(
-    output: UnsafePointer[Scalar[dtype]], a: UnsafePointer[Scalar[dtype]]
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     i = thread_idx.x
     output[i] = a[i] + 10.0

--- a/problems/p11/p11.mojo
+++ b/problems/p11/p11.mojo
@@ -14,8 +14,8 @@ alias dtype = DType.float32
 
 
 fn pooling(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     shared = stack_allocation[

--- a/problems/p12/p12.mojo
+++ b/problems/p12/p12.mojo
@@ -14,9 +14,9 @@ alias dtype = DType.float32
 
 
 fn dot_product(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
-    b: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     # FILL ME IN (roughly 13 lines)

--- a/problems/p17/op/conv1d.mojo
+++ b/problems/p17/op/conv1d.mojo
@@ -104,7 +104,7 @@ struct Conv1DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
                         output_tensor.ptr
                     ),
                     input_size,

--- a/problems/p18/op/softmax.mojo
+++ b/problems/p18/op/softmax.mojo
@@ -79,7 +79,7 @@ struct SoftmaxCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
                         output_tensor.ptr
                     ),
                     input_size,

--- a/problems/p20/op/conv1d.mojo
+++ b/problems/p20/op/conv1d.mojo
@@ -107,7 +107,9 @@ struct Conv1DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](out_tensor.ptr),
+                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
+                        out_tensor.ptr
+                    ),
                     input_size,
                     owning=False,
                 ),

--- a/problems/p21/op/embedding.mojo
+++ b/problems/p21/op/embedding.mojo
@@ -140,7 +140,7 @@ struct EmbeddingCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
                         output_tensor.ptr
                     ),
                     batch_size * seq_len * embed_dim,
@@ -225,7 +225,7 @@ struct Embedding2DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
                         output_tensor.ptr
                     ),
                     batch_size * seq_len * embed_dim,

--- a/solutions/p01/p01.mojo
+++ b/solutions/p01/p01.mojo
@@ -11,7 +11,8 @@ alias dtype = DType.float32
 
 # ANCHOR: add_10_solution
 fn add_10(
-    output: UnsafePointer[Scalar[dtype]], a: UnsafePointer[Scalar[dtype]]
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     i = thread_idx.x
     output[i] = a[i] + 10.0

--- a/solutions/p02/p02.mojo
+++ b/solutions/p02/p02.mojo
@@ -11,9 +11,9 @@ alias dtype = DType.float32
 
 # ANCHOR: add_solution
 fn add(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
-    b: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     i = thread_idx.x
     output[i] = a[i] + b[i]

--- a/solutions/p03/p03.mojo
+++ b/solutions/p03/p03.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 # ANCHOR: add_10_guard_solution
 fn add_10_guard(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     i = thread_idx.x

--- a/solutions/p04/p04.mojo
+++ b/solutions/p04/p04.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 # ANCHOR: add_10_2d_solution
 fn add_10_2d(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     row = thread_idx.y

--- a/solutions/p05/p05.mojo
+++ b/solutions/p05/p05.mojo
@@ -11,9 +11,9 @@ alias dtype = DType.float32
 
 # ANCHOR: broadcast_add_solution
 fn broadcast_add(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
-    b: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     row = thread_idx.y

--- a/solutions/p06/p06.mojo
+++ b/solutions/p06/p06.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 # ANCHOR: add_10_blocks_solution
 fn add_10_blocks(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     i = block_dim.x * block_idx.x + thread_idx.x

--- a/solutions/p07/p07.mojo
+++ b/solutions/p07/p07.mojo
@@ -11,8 +11,8 @@ alias dtype = DType.float32
 
 # ANCHOR: add_10_blocks_2d_solution
 fn add_10_blocks_2d(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     row = block_dim.y * block_idx.y + thread_idx.y

--- a/solutions/p08/p08.mojo
+++ b/solutions/p08/p08.mojo
@@ -14,8 +14,8 @@ alias dtype = DType.float32
 
 # ANCHOR: add_10_shared_solution
 fn add_10_shared(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     shared = stack_allocation[

--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -14,8 +14,8 @@ alias dtype = DType.float32
 
 # ANCHOR: pooling_solution
 fn pooling(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     shared = stack_allocation[

--- a/solutions/p12/p12.mojo
+++ b/solutions/p12/p12.mojo
@@ -14,9 +14,9 @@ alias dtype = DType.float32
 
 # ANCHOR: dot_product_solution
 fn dot_product(
-    output: UnsafePointer[Scalar[dtype]],
-    a: UnsafePointer[Scalar[dtype]],
-    b: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     shared = stack_allocation[

--- a/solutions/p17/op/conv1d.mojo
+++ b/solutions/p17/op/conv1d.mojo
@@ -103,7 +103,7 @@ struct Conv1DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
                         output_tensor.ptr
                     ),
                     input_size,

--- a/solutions/p18/op/softmax.mojo
+++ b/solutions/p18/op/softmax.mojo
@@ -144,7 +144,7 @@ struct SoftmaxCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output_tensor.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
                         output_tensor.ptr
                     ),
                     input_size,

--- a/solutions/p20/op/conv1d.mojo
+++ b/solutions/p20/op/conv1d.mojo
@@ -104,7 +104,9 @@ struct Conv1DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](out_tensor.ptr),
+                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
+                        out_tensor.ptr
+                    ),
                     input_size,
                     owning=False,
                 ),

--- a/solutions/p21/op/embedding.mojo
+++ b/solutions/p21/op/embedding.mojo
@@ -157,7 +157,7 @@ struct EmbeddingCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
                         output_tensor.ptr
                     ),
                     batch_size * seq_len * embed_dim,
@@ -246,7 +246,7 @@ struct Embedding2DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[UnsafePointer[Scalar[output.dtype]]](
+                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
                         output_tensor.ptr
                     ),
                     batch_size * seq_len * embed_dim,


### PR DESCRIPTION
The new `UnsafePointer` type behaves similarly to `LayoutTensor` now requiring users to manually specify an origin. This may be updated/changed for usability in the future but this is needed for the 25.7 release.