### PR TITLE
Fix missing dependency: pynvml (required by gpu-specs.py)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "poethepoet>=0.34.0",
     "scipy>=1.15.3",
     "torch==2.7.1",
+    "pynvml>=13.0.1",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
```bash
❯ uv run poe gpu-specs
Poe => python scripts/gpu_specs.py
Detected Platform: Nvidia

Error detecting GPU specifications: Failed to get NVIDIA GPU specs: No module named 'pynvml'
❯ uv add pynvml
Resolved 50 packages in 2.06s
Prepared 2 packages in 176ms
Installed 2 packages in 4ms
 + nvidia-ml-py==13.580.82
 + pynvml==13.0.1
```