### PR TITLE
Update `vectorize` usage in puzzle 23 to new unified closure syntax

### DIFF
--- a/book/src/puzzle_23/vectorize.md
+++ b/book/src/puzzle_23/vectorize.md
@@ -239,8 +239,9 @@ Handle cases where the last tile might be smaller than `tile_size`.
 ### 2. **Vectorized function pattern**
 
 ```mojo
-@parameter
-fn vectorized_add[width: Int](i: Int):
+fn vectorized_add[
+  width: Int
+](i: Int) unified {read tile_start, read a, read b, mut output}:
     global_idx = tile_start + i
     if global_idx + width <= size:  # Bounds checking
         # SIMD operations here
@@ -251,7 +252,7 @@ The `width` parameter is automatically determined by the vectorize function.
 ### 3. **Calling vectorize**
 
 ```mojo
-vectorize[vectorized_add, simd_width](actual_tile_size)
+vectorize[simd_width](actual_tile_size, vectorized_add)
 ```
 
 This automatically handles the vectorization loop with the provided SIMD width.
@@ -337,8 +338,9 @@ actual_tile_size = tile_end - tile_start
 **Automatic vectorization mechanism:**
 
 ```mojo
-@parameter
-fn vectorized_add[width: Int](i: Int):
+fn vectorized_add[
+  width: Int
+](i: Int) unified {read tile_start, read a, read b, mut output}:
     global_idx = tile_start + i
     if global_idx + width <= size:
         # Automatic SIMD optimization

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ system-requirements = { macos = "15.0" }
 [dependencies]
 python = "==3.12"
 mojo = "<1.0.0" # includes `mojo-compiler`, lsp, debugger, formatter etc.
-max = "==25.7.0.dev2025111305"
+max = "==26.1.0.dev2025112105"
 bash = ">=5.2.21,<6"
 manim = ">=0.18.1,<0.19"
 mdbook = ">=0.4.48,<0.5"

--- a/solutions/p23/p23.mojo
+++ b/solutions/p23/p23.mojo
@@ -166,8 +166,9 @@ fn vectorize_within_tiles_elementwise_add[
         tile_end = min(tile_start + tile_size, size)
         actual_tile_size = tile_end - tile_start
 
-        @parameter
-        fn vectorized_add[width: Int](i: Int):
+        fn vectorized_add[
+            width: Int
+        ](i: Int) unified {read tile_start, read a, read b, mut output}:
             global_idx = tile_start + i
             if global_idx + width <= size:
                 a_vec = a.aligned_load[width](global_idx, 0)
@@ -176,7 +177,7 @@ fn vectorize_within_tiles_elementwise_add[
                 output.aligned_store[width](global_idx, 0, result)
 
         # Use vectorize within each tile
-        vectorize[vectorized_add, simd_width](actual_tile_size)
+        vectorize[simd_width](actual_tile_size, vectorized_add)
 
     num_tiles = (size + tile_size - 1) // tile_size
     elementwise[


### PR DESCRIPTION
In the latest nightlies, new `unified` closures are beginning to replace the older `@parameter` and runtime closures. `vectorize` is the first place where these have started to appear, and that breaks puzzle 23 on the latest nightly.

This updates the `vectorize` puzzle and solution to use the new closure syntax, and moves the pin for `max` to the latest nightly. This should restore that puzzle to building correctly on the latest nightlies.