### PR TITLE
Enable puzzles 19 and 28 on macOS

### DIFF
--- a/book/src/howto.md
+++ b/book/src/howto.md
@@ -267,7 +267,7 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 | **Part IV: MAX Graph** | | | | |
 | 17 - Custom Op | ✅ | ✅ | ✅ | MAX Graph integration |
 | 18 - Softmax | ✅ | ✅ | ✅ | MAX Graph integration |
-| 19 - Attention | ✅ | ✅ | ❌ | MAX Graph integration |
+| 19 - Attention | ✅ | ✅ | ✅ | MAX Graph integration |
 | **Part V: PyTorch Integration** | | | | |
 | 20 - Torch Bridge | ✅ | ✅ | ❌ | PyTorch integration |
 | 21 - Autograd | ✅ | ✅ | ❌ | PyTorch integration |
@@ -281,7 +281,7 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 | **Part VIII: Block Programming** | | | | |
 | 27 - Block Operations | ✅ | ✅ | ✅ | Block-level patterns |
 | **Part IX: Memory Systems** | | | | |
-| 28 - Async Memory | ✅ | ✅ | ❌ | Advanced memory operations |
+| 28 - Async Memory | ✅ | ✅ | ✅ | Advanced memory operations |
 | 29 - Barriers | ✅ | ✅ | ❌ | Advanced synchronization |
 | **Part X: Performance Analysis** | | | | |
 | 30 - Profiling | ✅ | ❌ | ❌ | NVIDIA profiling tools (NSight) |

--- a/book/src/puzzle_19/puzzle_19.md
+++ b/book/src/puzzle_19/puzzle_19.md
@@ -156,6 +156,7 @@ To complete this puzzle, we'll leverage the tiled matmul kernel from [Puzzle 16]
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -169,6 +170,13 @@ pixi run p19
 
 ```bash
 pixi run -e amd p19
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p19
 ```
 
   </div>

--- a/book/src/puzzle_28/puzzle_28.md
+++ b/book/src/puzzle_28/puzzle_28.md
@@ -274,6 +274,7 @@ Proper synchronization ensures correctness without sacrificing performance.
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -287,6 +288,13 @@ pixi run p28
 
 ```bash
 pixi run -e amd p28
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p28
 ```
 
   </div>

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ system-requirements = { macos = "15.0" }
 [dependencies]
 python = "==3.12"
 mojo = "<1.0.0" # includes `mojo-compiler`, lsp, debugger, formatter etc.
-max = "==26.1.0.dev2025112105"
+max = "==26.1.0.dev2025121405"
 bash = ">=5.2.21,<6"
 manim = ">=0.18.1,<0.19"
 mdbook = ">=0.4.48,<0.5"

--- a/solutions/run.sh
+++ b/solutions/run.sh
@@ -38,7 +38,7 @@ NVIDIA_COMPUTE_90_REQUIRED_PUZZLES=("p34")
 AMD_UNSUPPORTED_PUZZLES=("p09" "p10" "p30" "p31" "p32" "p33" "p34")
 
 # Puzzles that are not supported on Apple GPUs
-APPLE_UNSUPPORTED_PUZZLES=("p09" "p10" "p16" "p19" "p20" "p21" "p22" "p28" "p29" "p30" "p31" "p32" "p33" "p34")
+APPLE_UNSUPPORTED_PUZZLES=("p09" "p10" "p16" "p20" "p21" "p22" "p29" "p30" "p31" "p32" "p33" "p34")
 
 # Arrays to store results
 declare -a FAILED_TESTS_LIST
@@ -685,7 +685,7 @@ print_startup_banner() {
             ;;
         "apple")
             echo -e "  ${BULLET} Metal Support: ${GREEN}Available${NC}"
-            echo -e "  ${BULLET} Auto-Skip: ${YELLOW}Some puzzles unsupported${NC} ${GRAY}(14 puzzles will be skipped)${NC}"
+            echo -e "  ${BULLET} Auto-Skip: ${YELLOW}Some puzzles unsupported${NC} ${GRAY}(12 puzzles will be skipped)${NC}"
             ;;
         *)
             echo -e "  ${BULLET} Status: ${YELLOW}Unknown GPU platform${NC}"


### PR DESCRIPTION
Recent upstream fixes have allowed puzzles 19 and 28 to start working on Apple silicon GPUs. This enables those puzzles, and updates the pinned version of MAX to match the latest capabilities.