### PR TITLE
Enable puzzle 16 for macOS

### DIFF
--- a/book/src/howto.md
+++ b/book/src/howto.md
@@ -263,7 +263,7 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 | 13 - Pool | ✅ | ✅ | ✅ | Basic GPU kernels |
 | 14 - Conv | ✅ | ✅ | ✅ | Basic GPU kernels |
 | 15 - Matmul | ✅ | ✅ | ✅ | Basic GPU kernels |
-| 16 - Flashdot | ✅ | ✅ | ❌ | Advanced memory patterns |
+| 16 - Flashdot | ✅ | ✅ | ✅ | Advanced memory patterns |
 | **Part IV: MAX Graph** | | | | |
 | 17 - Custom Op | ✅ | ✅ | ✅ | MAX Graph integration |
 | 18 - Softmax | ✅ | ✅ | ✅ | MAX Graph integration |
@@ -282,7 +282,7 @@ The following table shows GPU platform compatibility for each puzzle. Different 
 | 27 - Block Operations | ✅ | ✅ | ✅ | Block-level patterns |
 | **Part IX: Memory Systems** | | | | |
 | 28 - Async Memory | ✅ | ✅ | ✅ | Advanced memory operations |
-| 29 - Barriers | ✅ | ❌ | ❌ | Advanced NVIIDA-only synchronization |
+| 29 - Barriers | ✅ | ❌ | ❌ | Advanced NVIDIA-only synchronization |
 | **Part X: Performance Analysis** | | | | |
 | 30 - Profiling | ✅ | ❌ | ❌ | NVIDIA profiling tools (NSight) |
 | 31 - Occupancy | ✅ | ❌ | ❌ | NVIDIA profiling tools |

--- a/book/src/puzzle_16/naïve.md
+++ b/book/src/puzzle_16/naïve.md
@@ -57,6 +57,7 @@ To test your solution, run the following command in your terminal:
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -70,6 +71,13 @@ pixi run p16 --naive
 
 ```bash
 pixi run -e amd p16 --naive
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p16 --naive
 ```
 
   </div>

--- a/book/src/puzzle_16/shared_memory.md
+++ b/book/src/puzzle_16/shared_memory.md
@@ -66,6 +66,7 @@ To test your solution, run the following command in your terminal:
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -79,6 +80,13 @@ pixi run p16 --single-block
 
 ```bash
 pixi run -e amd p16 --single-block
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p16 --single-block
 ```
 
   </div>

--- a/book/src/puzzle_16/tiled.md
+++ b/book/src/puzzle_16/tiled.md
@@ -150,6 +150,7 @@ To test your solution, run the following command in your terminal:
   <div class="tab-buttons">
     <button class="tab-button">pixi NVIDIA (default)</button>
     <button class="tab-button">pixi AMD</button>
+    <button class="tab-button">pixi Apple</button>
     <button class="tab-button">uv</button>
   </div>
   <div class="tab-content">
@@ -163,6 +164,13 @@ pixi run p16 --tiled
 
 ```bash
 pixi run -e amd p16 --tiled
+```
+
+  </div>
+  <div class="tab-content">
+
+```bash
+pixi run -e apple p16 --tiled
 ```
 
   </div>

--- a/solutions/run.sh
+++ b/solutions/run.sh
@@ -38,7 +38,7 @@ NVIDIA_COMPUTE_90_REQUIRED_PUZZLES=("p34")
 AMD_UNSUPPORTED_PUZZLES=("p09" "p10" "p30" "p31" "p32" "p33" "p34")
 
 # Puzzles that are not supported on Apple GPUs
-APPLE_UNSUPPORTED_PUZZLES=("p09" "p10" "p16" "p20" "p21" "p22" "p29" "p30" "p31" "p32" "p33" "p34")
+APPLE_UNSUPPORTED_PUZZLES=("p09" "p10" "p20" "p21" "p22" "p29" "p30" "p31" "p32" "p33" "p34")
 
 # Arrays to store results
 declare -a FAILED_TESTS_LIST
@@ -685,7 +685,7 @@ print_startup_banner() {
             ;;
         "apple")
             echo -e "  ${BULLET} Metal Support: ${GREEN}Available${NC}"
-            echo -e "  ${BULLET} Auto-Skip: ${YELLOW}Some puzzles unsupported${NC} ${GRAY}(12 puzzles will be skipped)${NC}"
+            echo -e "  ${BULLET} Auto-Skip: ${YELLOW}Some puzzles unsupported${NC} ${GRAY}(11 puzzles will be skipped)${NC}"
             ;;
         *)
             echo -e "  ${BULLET} Status: ${YELLOW}Unknown GPU platform${NC}"


### PR DESCRIPTION
I missed it in my last PR, but puzzle 16 is now operational on Apple silicon GPUs as of the latest nightlies.