### PR TITLE
Declare index as Int so it can be used in Int - Int operations

### DIFF
--- a/problems/p30/p30.mojo
+++ b/problems/p30/p30.mojo
@@ -24,7 +24,7 @@ fn kernel1[
     b: LayoutTensor[dtype, layout, ImmutAnyOrigin],
     size: Int,
 ):
-    i = block_dim.x * block_idx.x + thread_idx.x
+    i = Int(block_dim.x * block_idx.x + thread_idx.x)
     if i < size:
         output[i] = a[i] + b[i]
 
@@ -41,7 +41,7 @@ fn kernel2[
     b: LayoutTensor[dtype, layout, ImmutAnyOrigin],
     size: Int,
 ):
-    tid = block_idx.x * block_dim.x + thread_idx.x
+    tid = Int(block_idx.x * block_dim.x + thread_idx.x)
     stride = 512
 
     i = tid
@@ -62,7 +62,7 @@ fn kernel3[
     b: LayoutTensor[dtype, layout, ImmutAnyOrigin],
     size: Int,
 ):
-    tid = block_idx.x * block_dim.x + thread_idx.x
+    tid = Int(block_idx.x * block_dim.x + thread_idx.x)
     total_threads = (SIZE // 1024) * 1024
 
     for step in range(0, size, total_threads):

--- a/problems/p31/p31.mojo
+++ b/problems/p31/p31.mojo
@@ -24,7 +24,7 @@ fn minimal_kernel[
     size: Int,
 ):
     """Minimal SAXPY kernel - simple and register-light for high occupancy."""
-    i = block_dim.x * block_idx.x + thread_idx.x
+    i = Int(block_dim.x * block_idx.x + thread_idx.x)
     if i < size:
         # Direct computation: y[i] = alpha * x[i] + y[i]
         # Uses minimal registers (~8), no shared memory
@@ -53,7 +53,7 @@ fn sophisticated_kernel[
         address_space = AddressSpace.SHARED,
     ].stack_allocation()  # 48KB
 
-    i = block_dim.x * block_idx.x + thread_idx.x
+    i = Int(block_dim.x * block_idx.x + thread_idx.x)
     local_i = thread_idx.x
 
     if i < size:
@@ -150,7 +150,7 @@ fn balanced_kernel[
         address_space = AddressSpace.SHARED,
     ].stack_allocation()  # 16KB total
 
-    i = block_dim.x * block_idx.x + thread_idx.x
+    i = Int(block_dim.x * block_idx.x + thread_idx.x)
     local_i = thread_idx.x
 
     if i < size:

--- a/problems/p32/p32.mojo
+++ b/problems/p32/p32.mojo
@@ -36,7 +36,7 @@ fn no_conflict_kernel[
         address_space = AddressSpace.SHARED,
     ].stack_allocation()
 
-    global_i = block_dim.x * block_idx.x + thread_idx.x
+    global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
     local_i = thread_idx.x
 
     # Load from global memory to shared memory - no conflicts
@@ -79,7 +79,7 @@ fn two_way_conflict_kernel[
         address_space = AddressSpace.SHARED,
     ].stack_allocation()
 
-    global_i = block_dim.x * block_idx.x + thread_idx.x
+    global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
     local_i = thread_idx.x
 
     # CONFLICT: stride-2 access creates 2-way bank conflicts


### PR DESCRIPTION
declare index as Int() when used in < operations later.