### PR TITLE
Fix compile issues due to some LegacyUnsafePointer changes

### DIFF
--- a/problems/p17/op/conv1d.mojo
+++ b/problems/p17/op/conv1d.mojo
@@ -104,9 +104,7 @@ struct Conv1DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
-                        output_tensor.ptr
-                    ),
+                    output_tensor.ptr,
                     input_size,
                     owning=False,
                 ),

--- a/problems/p18/op/softmax.mojo
+++ b/problems/p18/op/softmax.mojo
@@ -79,9 +79,7 @@ struct SoftmaxCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
-                        output_tensor.ptr
-                    ),
+                    output_tensor.ptr,
                     input_size,
                     owning=False,
                 ),

--- a/problems/p21/op/embedding.mojo
+++ b/problems/p21/op/embedding.mojo
@@ -140,9 +140,7 @@ struct EmbeddingCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
-                        output_tensor.ptr
-                    ),
+                    output_tensor.ptr,
                     batch_size * seq_len * embed_dim,
                     owning=False,
                 ),

--- a/solutions/p17/op/conv1d.mojo
+++ b/solutions/p17/op/conv1d.mojo
@@ -103,9 +103,7 @@ struct Conv1DCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
-                        output_tensor.ptr
-                    ),
+                    output_tensor.ptr,
                     input_size,
                     owning=False,
                 ),

--- a/solutions/p18/op/softmax.mojo
+++ b/solutions/p18/op/softmax.mojo
@@ -144,9 +144,7 @@ struct SoftmaxCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output_tensor.dtype](
                     gpu_ctx,
-                    rebind[LegacyUnsafePointer[Scalar[output_tensor.dtype]]](
-                        output_tensor.ptr
-                    ),
+                    output_tensor.ptr,
                     input_size,
                     owning=False,
                 ),

--- a/solutions/p21/op/embedding.mojo
+++ b/solutions/p21/op/embedding.mojo
@@ -157,9 +157,7 @@ struct EmbeddingCustomOp:
             gpu_ctx.enqueue_memset(
                 DeviceBuffer[output.dtype](
                     gpu_ctx,
-                    rebind[LegacyUnsafePointer[Scalar[output.dtype]]](
-                        output_tensor.ptr
-                    ),
+                    output_tensor.ptr,
                     batch_size * seq_len * embed_dim,
                     owning=False,
                 ),


### PR DESCRIPTION
This can either be fixed by adding a `mut = True` (see #187, that theoretically should also work), but according to Chris this should work too and be simpler.