### PR TITLE
Update LayoutTensor coordinate access for 1D tensors

### DIFF
--- a/book/src/puzzle_23/elementwise.md
+++ b/book/src/puzzle_23/elementwise.md
@@ -73,11 +73,11 @@ This `idx` represents the **starting position** for a SIMD vector, not a single 
 ### 3. **SIMD loading pattern**
 
 ```mojo
-a_simd = a.aligned_load[simd_width](idx, 0)  # Load 4 consecutive floats (GPU-dependent)
-b_simd = b.aligned_load[simd_width](idx, 0)  # Load 4 consecutive floats (GPU-dependent)
+a_simd = a.aligned_load[simd_width](idx)  # Load 4 consecutive floats (GPU-dependent)
+b_simd = b.aligned_load[simd_width](idx)  # Load 4 consecutive floats (GPU-dependent)
 ```
 
-The second parameter `0` is the dimension offset (always 0 for 1D vectors). This loads a **vectorized chunk** of data in a single operation. The exact number of elements loaded depends on your GPU's SIMD capabilities.
+This loads a **vectorized chunk** of data in a single operation starting at index `idx`. The exact number of elements loaded depends on your GPU's SIMD capabilities.
 
 ### 4. **Vector arithmetic**
 
@@ -90,7 +90,7 @@ This performs element-wise addition across the entire SIMD vector (if supported)
 ### 5. **SIMD storing**
 
 ```mojo
-output.store[simd_width](idx, 0, result)  # Store 4 results at once (GPU-dependent)
+output.aligned_store[simd_width](idx, result)  # Store 4 results at once (GPU-dependent)
 ```
 
 Writes the entire SIMD vector back to memory in one operation.
@@ -234,10 +234,10 @@ fn add[simd_width: Int, rank: Int](indices: IndexList[rank]) capturing -> None:
 
 ```mojo
 idx = indices[0]                                  # Linear index: 0, 4, 8, 12... (GPU-dependent spacing)
-a_simd = a.aligned_load[simd_width](idx, 0)       # Load: [a[0:4], a[4:8], a[8:12]...] (4 elements per load)
-b_simd = b.aligned_load[simd_width](idx, 0)       # Load: [b[0:4], b[4:8], b[8:12]...] (4 elements per load)
+a_simd = a.aligned_load[simd_width](idx)          # Load: [a[0:4], a[4:8], a[8:12]...] (4 elements per load)
+b_simd = b.aligned_load[simd_width](idx)          # Load: [b[0:4], b[4:8], b[8:12]...] (4 elements per load)
 ret = a_simd + b_simd                             # SIMD: 4 additions in parallel (GPU-dependent)
-output.aligned_store[simd_width](idx, 0, ret)     # Store: 4 results simultaneously (GPU-dependent)
+output.aligned_store[simd_width](idx, ret)        # Store: 4 results simultaneously (GPU-dependent)
 ```
 
 **Execution Hierarchy Visualization:**
@@ -266,7 +266,7 @@ GPU Architecture:
 ### 4. **Memory access pattern analysis**
 
 ```mojo
-a.aligned_load[simd_width](idx, 0)  // Coalesced memory access
+a.aligned_load[simd_width](idx)  // Coalesced memory access
 ```
 
 **Memory Coalescing Benefits:**

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -121,8 +121,8 @@ fn functional_warp_dot_product[
         # Each thread computes one partial product
         var partial_product: Scalar[dtype] = 0.0
         if idx < size:
-            a_val = a.load[1](idx, 0)
-            b_val = b.load[1](idx, 0)
+            a_val = a.load[1](idx)
+            b_val = b.load[1](idx)
             partial_product = a_val * b_val
         else:
             partial_product = 0.0
@@ -132,7 +132,7 @@ fn functional_warp_dot_product[
 
         # Only lane 0 writes the result (all lanes have the same total)
         if lane_id() == 0:
-            output.store[1](idx // WARP_SIZE, 0, total)
+            output.store[1](idx // WARP_SIZE, total)
 
     # Launch exactly size == WARP_SIZE threads (one warp) to process all elements
     elementwise[compute_dot_product, 1, target="gpu"](size, ctx)


### PR DESCRIPTION
Updates load/store calls to use single coordinates for rank-1 tensors.
The old 2-coordinate pattern (idx, 0) is now rejected by bounds checking, this 
is introduced in the upcoming "[Kernels] Use static strides for IndexList offsets"