### PR TITLE
Keep p03 block_dim 1D

### DIFF
--- a/problems/p03/p03.mojo
+++ b/problems/p03/p03.mojo
@@ -6,7 +6,7 @@ from testing import assert_equal
 # ANCHOR: add_10_guard
 comptime SIZE = 4
 comptime BLOCKS_PER_GRID = 1
-comptime THREADS_PER_BLOCK = (8, 1)
+comptime THREADS_PER_BLOCK = 8
 comptime dtype = DType.float32
 
 

--- a/solutions/p03/p03.mojo
+++ b/solutions/p03/p03.mojo
@@ -5,7 +5,7 @@ from testing import assert_equal
 
 comptime SIZE = 4
 comptime BLOCKS_PER_GRID = 1
-comptime THREADS_PER_BLOCK = (8, 1)
+comptime THREADS_PER_BLOCK = 8
 comptime dtype = DType.float32
 
 


### PR DESCRIPTION
Avoid introducing unused concept for early exercise, multi-dim indexing first used in p04