### PR TITLE
Roll back nightly version to account for regression in Apple silicon GPU support

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ system-requirements = { macos = "15.0" }
 [dependencies]
 python = "==3.12"
 mojo = "<1.0.0" # includes `mojo-compiler`, lsp, debugger, formatter etc.
-max = "==26.2.0.dev2026013115"
+max = "==26.2.0.dev2026013005"
 bash = ">=5.2.21,<6"
 manim = ">=0.18.1,<0.19"
 mdbook = ">=0.4.48,<0.5"


### PR DESCRIPTION
There appears to have been a pretty severe regression in Apple silicon GPU support starting with the `26.2.0.dev2026013115` nightly release. All Apple silicon GPU tests fail at that release forward.

This rolls back the locked version to the last-known-good `26.2.0.dev2026013005` version while we investigate.