### PR TITLE
Update to new `comptime assert` syntax

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ system-requirements = { macos = "15.0" }
 [dependencies]
 python = "==3.12"
 mojo = "<1.0.0" # includes `mojo-compiler`, lsp, debugger, formatter etc.
-max = "==26.2.0.dev2026013005"
+max = "==26.2.0.dev2026020505"
 bash = ">=5.2.21,<6"
 manim = ">=0.18.1,<0.19"
 mdbook = ">=0.4.48,<0.5"

--- a/problems/p18/op/softmax.mojo
+++ b/problems/p18/op/softmax.mojo
@@ -25,7 +25,7 @@ fn softmax_gpu_kernel[
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     input: LayoutTensor[dtype, layout, ImmutAnyOrigin],
 ):
-    __comptime_assert (
+    comptime assert (
         dtype.is_floating_point()
     ), "dtype must be a floating-point type"
     # FILL IN (roughly 31 lines)
@@ -44,7 +44,7 @@ fn softmax_cpu_kernel[
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     input: LayoutTensor[dtype, layout, ImmutAnyOrigin],
 ):
-    __comptime_assert (
+    comptime assert (
         dtype.is_floating_point()
     ), "dtype must be a floating-point type"
     # FILL IN (roughly 10 lines)

--- a/problems/p19/op/attention.mojo
+++ b/problems/p19/op/attention.mojo
@@ -143,7 +143,7 @@ fn softmax_gpu_kernel[
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     input: LayoutTensor[dtype, layout, MutAnyOrigin],
 ):
-    __comptime_assert (
+    comptime assert (
         dtype.is_floating_point()
     ), "dtype must be a floating-point type"
     shared_max = LayoutTensor[

--- a/solutions/p18/op/softmax.mojo
+++ b/solutions/p18/op/softmax.mojo
@@ -24,7 +24,7 @@ fn softmax_gpu_kernel[
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     input: LayoutTensor[dtype, layout, ImmutAnyOrigin],
 ):
-    __comptime_assert (
+    comptime assert (
         dtype.is_floating_point()
     ), "dtype must be a floating-point type"
     shared_max = LayoutTensor[
@@ -99,7 +99,7 @@ fn softmax_cpu_kernel[
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     input: LayoutTensor[dtype, layout, ImmutAnyOrigin],
 ):
-    __comptime_assert (
+    comptime assert (
         dtype.is_floating_point()
     ), "dtype must be a floating-point type"
     var max_val: Scalar[dtype] = min_finite[dtype]()

--- a/solutions/p19/op/attention.mojo
+++ b/solutions/p19/op/attention.mojo
@@ -167,7 +167,7 @@ fn softmax_gpu_kernel[
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     input: LayoutTensor[dtype, layout, MutAnyOrigin],
 ):
-    __comptime_assert (
+    comptime assert (
         dtype.is_floating_point()
     ), "dtype must be a floating-point type"
     shared_max = LayoutTensor[


### PR DESCRIPTION
In the latest nightlies, `_comptime_assert` has now become `comptime assert` as we unify naming on compile-time functionality. This updates to the latest nightly and should get rid of these deprecation warnings.