### PR TITLE
Changed max.driver Tensor -> max.driver Buffer for p20

### DIFF
--- a/problems/p20/p20.py
+++ b/problems/p20/p20.py
@@ -49,7 +49,7 @@ def conv1d_max_graph_reference(
     Reference implementation using MAX Graph (like p15) for comparison.
     This shows the difference between MAX Graph and PyTorch approaches.
     """
-    from max.driver import CPU, Accelerator, Tensor, accelerator_count
+    from max.driver import CPU, Accelerator, Buffer, accelerator_count
     from max.dtype import DType
     from max.engine import InferenceSession
     from max.graph import DeviceRef, Graph, TensorType, ops
@@ -63,8 +63,8 @@ def conv1d_max_graph_reference(
     session = InferenceSession(devices=[device_obj])
 
     # Convert to MAX Graph tensors
-    input_tensor = Tensor.from_numpy(input_array).to(device_obj)
-    kernel_tensor = Tensor.from_numpy(kernel_array).to(device_obj)
+    input_tensor = Buffer.from_numpy(input_array).to(device_obj)
+    kernel_tensor = Buffer.from_numpy(kernel_array).to(device_obj)
 
     # Same graph setup as p15
     with Graph(

--- a/solutions/p20/p20.py
+++ b/solutions/p20/p20.py
@@ -45,7 +45,7 @@ def conv1d_max_graph_reference(
     Reference implementation using MAX Graph (like p15) for comparison.
     This shows the difference between MAX Graph and PyTorch approaches.
     """
-    from max.driver import CPU, Accelerator, Tensor, accelerator_count
+    from max.driver import CPU, Accelerator, Buffer, accelerator_count
     from max.dtype import DType
     from max.engine import InferenceSession
     from max.graph import DeviceRef, Graph, TensorType, ops
@@ -59,8 +59,8 @@ def conv1d_max_graph_reference(
     session = InferenceSession(devices=[device_obj])
 
     # Convert to MAX Graph tensors
-    input_tensor = Tensor.from_numpy(input_array).to(device_obj)
-    kernel_tensor = Tensor.from_numpy(kernel_array).to(device_obj)
+    input_tensor = Buffer.from_numpy(input_array).to(device_obj)
+    kernel_tensor = Buffer.from_numpy(kernel_array).to(device_obj)
 
     # Same graph setup as p15
     with Graph(


### PR DESCRIPTION
Only the code for problem 20 is using a legacy call to `from max.driver import Tensor` which yields the following error
`MAX Graph comparison failed: cannot import name 'Tensor' from 'max.driver'` for the current `max = "==26.2.0.dev2026020505"` dependency on `pixi.toml`.

I did a quick grep analysis and only problem 20 is doing the legacy import.