### PR TITLE
Took out size_of unused import and added missing "." in p09 docs

### DIFF
--- a/book/src/puzzle_09/first_case.md
+++ b/book/src/puzzle_09/first_case.md
@@ -154,7 +154,7 @@ input_buf = ctx.enqueue_create_buffer[dtype](0)
 
 # Correct: Allocates and initialize actual GPU memory for safe processing
 input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
-input_bufenqueue_fill(0)
+input_buf.enqueue_fill(0)
 ```
 
 ## Key debugging lessons

--- a/problems/p11/p11.mojo
+++ b/problems/p11/p11.mojo
@@ -2,7 +2,6 @@ from memory import UnsafePointer, stack_allocation
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
-from sys import size_of
 from testing import assert_equal
 
 # ANCHOR: pooling

--- a/problems/p12/p12.mojo
+++ b/problems/p12/p12.mojo
@@ -2,7 +2,6 @@ from memory import UnsafePointer, stack_allocation
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
-from sys import size_of
 from testing import assert_equal
 
 # ANCHOR: dot_product

--- a/problems/p13/p13.mojo
+++ b/problems/p13/p13.mojo
@@ -2,7 +2,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 # ANCHOR: conv_1d_simple

--- a/problems/p14/p14.mojo
+++ b/problems/p14/p14.mojo
@@ -2,7 +2,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from math import log2
 from testing import assert_equal
 

--- a/problems/p15/p15.mojo
+++ b/problems/p15/p15.mojo
@@ -1,4 +1,3 @@
-from sys import size_of
 from testing import assert_equal
 from gpu.host import DeviceContext
 

--- a/problems/p16/p16.mojo
+++ b/problems/p16/p16.mojo
@@ -1,4 +1,4 @@
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 from gpu.host import DeviceContext
 

--- a/problems/p20/op/conv1d.mojo
+++ b/problems/p20/op/conv1d.mojo
@@ -3,7 +3,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 comptime TPB = 15

--- a/problems/p21/op/embedding.mojo
+++ b/problems/p21/op/embedding.mojo
@@ -2,7 +2,7 @@ from math import ceildiv
 from gpu import thread_idx, block_idx, block_dim, grid_dim, barrier
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 # ANCHOR: embedding_kernel_coalesced

--- a/problems/p24/p24.mojo
+++ b/problems/p24/p24.mojo
@@ -6,7 +6,7 @@ from gpu.primitives.warp import sum as warp_sum, WARP_SIZE
 from algorithm.functional import elementwise
 from layout import Layout, LayoutTensor
 from utils import IndexList
-from sys import argv, simd_width_of, size_of, align_of
+from sys import argv, simd_width_of, align_of
 from testing import assert_equal
 from random import random_float64
 from benchmark import (

--- a/problems/p29/p29.mojo
+++ b/problems/p29/p29.mojo
@@ -11,7 +11,7 @@ from gpu.host import DeviceContext
 from gpu.memory import AddressSpace, async_copy_wait_all
 from layout import Layout, LayoutTensor
 from layout.layout_tensor import copy_dram_to_sram_async
-from sys import size_of, argv, info
+from sys import argv, info
 from testing import assert_true, assert_almost_equal
 
 # ANCHOR: multi_stage_pipeline

--- a/problems/p33/p33.mojo
+++ b/problems/p33/p33.mojo
@@ -5,7 +5,7 @@ from layout import Layout, LayoutTensor
 from layout.tensor_core import TensorCore
 from layout.layout_tensor import copy_dram_to_sram_async
 from utils import Index
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal, assert_almost_equal
 
 comptime dtype = DType.float32

--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -2,7 +2,6 @@ from memory import UnsafePointer, stack_allocation
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
-from sys import size_of
 from testing import assert_equal
 
 comptime TPB = 8

--- a/solutions/p12/p12.mojo
+++ b/solutions/p12/p12.mojo
@@ -2,7 +2,6 @@ from memory import UnsafePointer, stack_allocation
 from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
-from sys import size_of
 from testing import assert_equal
 
 comptime TPB = 8

--- a/solutions/p13/p13.mojo
+++ b/solutions/p13/p13.mojo
@@ -2,7 +2,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 comptime TPB = 8

--- a/solutions/p14/p14.mojo
+++ b/solutions/p14/p14.mojo
@@ -2,7 +2,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from math import log2
 from testing import assert_equal
 

--- a/solutions/p15/p15.mojo
+++ b/solutions/p15/p15.mojo
@@ -2,7 +2,6 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of
 from testing import assert_equal
 
 comptime TPB = 8

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -2,7 +2,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 comptime TPB = 3

--- a/solutions/p17/op/conv1d.mojo
+++ b/solutions/p17/op/conv1d.mojo
@@ -2,7 +2,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 comptime TPB = 15

--- a/solutions/p20/op/conv1d.mojo
+++ b/solutions/p20/op/conv1d.mojo
@@ -3,7 +3,7 @@ from gpu import thread_idx, block_idx, block_dim, barrier
 from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 comptime TPB = 15

--- a/solutions/p21/op/embedding.mojo
+++ b/solutions/p21/op/embedding.mojo
@@ -2,7 +2,7 @@ from math import ceildiv
 from gpu import thread_idx, block_idx, block_dim, grid_dim, barrier
 from gpu.host import DeviceContext
 from layout import Layout, LayoutTensor
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal
 
 comptime THREADS_PER_BLOCK = 256

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -6,7 +6,7 @@ from gpu.memory import AddressSpace
 from algorithm.functional import elementwise
 from layout import Layout, LayoutTensor
 from utils import Index, IndexList
-from sys import argv, simd_width_of, size_of, align_of
+from sys import argv, simd_width_of, align_of
 from testing import assert_equal
 from random import random_float64
 from benchmark import (

--- a/solutions/p29/p29.mojo
+++ b/solutions/p29/p29.mojo
@@ -8,7 +8,7 @@ from gpu.host import DeviceContext
 from gpu.memory import AddressSpace
 from layout import Layout, LayoutTensor
 from layout.layout_tensor import copy_dram_to_sram_async
-from sys import size_of, argv, info
+from sys import argv, info
 from testing import assert_true, assert_almost_equal
 
 comptime TPB = 256  # Threads per block for pipeline stages

--- a/solutions/p33/p33.mojo
+++ b/solutions/p33/p33.mojo
@@ -5,7 +5,7 @@ from layout.tensor_core import TensorCore
 from layout.layout_tensor import copy_dram_to_sram_async
 from gpu.memory import async_copy_wait_all, AddressSpace
 from utils import Index
-from sys import size_of, argv
+from sys import argv
 from testing import assert_equal, assert_almost_equal
 
 comptime dtype = DType.float32


### PR DESCRIPTION
I noticed that there were several `from sys import size_of` but that `size_of` was not used in the solutions.

I'm adding here the results of running `pixi run tests` as I modified several files. I'm using a NVIDIA GeForce RTX 3080 which does not have SM90+, that is why the test on p34 fails.

TEST SUMMARY

  Total Tests: 64
  Passed: 61
  Failed: 3
  Skipped: 0

  Success Rate: 95%


Failed Tests:
  ✗ p34/p34.mojo (--advanced)
  ✗ p34/p34.mojo (--coordination)
  ✗ p34/p34.mojo (--reduction)

✗ Some tests failed.

Execution time: 571s