### PR TITLE
Update all implicit type casts to be explicit

### DIFF
--- a/book/src/puzzle_26/puzzle_26.md
+++ b/book/src/puzzle_26/puzzle_26.md
@@ -115,7 +115,7 @@ Learn XOR-based butterfly communication patterns for efficient tree algorithms a
 max_val = input[global_i]
 offset = WARP_SIZE // 2
 while offset > 0:
-    max_val = max(max_val, shuffle_xor(max_val, offset))
+    max_val = max(max_val, shuffle_xor(max_val, UInt32(offset)))
     offset //= 2
 # All lanes now have global maximum
 ```

--- a/book/src/puzzle_26/warp_prefix_sum.md
+++ b/book/src/puzzle_26/warp_prefix_sum.md
@@ -391,7 +391,7 @@ if global_i < size:
     # Butterfly reduction to get total across the warp: dynamic for any WARP_SIZE
     offset = WARP_SIZE // 2
     while offset > 0:
-        warp_left_total += shuffle_xor(warp_left_total, offset)
+        warp_left_total += shuffle_xor(warp_left_total, UInt32(offset))
         offset //= 2
 
     # Phase 4: Write to output positions

--- a/book/src/puzzle_26/warp_shuffle_xor.md
+++ b/book/src/puzzle_26/warp_shuffle_xor.md
@@ -406,7 +406,7 @@ if global_i < size:
     # Butterfly reduction tree: dynamic for any WARP_SIZE
     offset = WARP_SIZE // 2
     while offset > 0:
-        max_val = max(max_val, shuffle_xor(max_val, offset))
+        max_val = max(max_val, shuffle_xor(max_val, UInt32(offset)))
         offset //= 2
 
     output[global_i] = max_val  # All lanes have global maximum
@@ -599,10 +599,10 @@ if global_i < size:
     # Butterfly reduction for both max and min log_2(WARP_SIZE}) steps)
     offset = WARP_SIZE // 2
     while offset > 0:
-        neighbor_val = shuffle_xor(current_val, offset)
+        neighbor_val = shuffle_xor(current_val, UInt32(offset))
         current_val = max(current_val, neighbor_val)    # Max reduction
 
-        min_neighbor_val = shuffle_xor(min_val, offset)
+        min_neighbor_val = shuffle_xor(min_val, UInt32(offset))
         min_val = min(min_val, min_neighbor_val)        # Min reduction
 
         offset //= 2
@@ -643,10 +643,10 @@ Final result: All lanes have current_val=7 (global max) and min_val=1 (global mi
 ```mojo
 offset = WARP_SIZE // 2
 while offset > 0:
-    neighbor_val = shuffle_xor(current_val, offset)
+    neighbor_val = shuffle_xor(current_val, UInt32(offset))
     current_val = max(current_val, neighbor_val)
 
-    min_neighbor_val = shuffle_xor(min_val, offset)
+    min_neighbor_val = shuffle_xor(min_val, UInt32(offset))
     min_val = min(min_val, min_neighbor_val)
 
     offset //= 2
@@ -710,7 +710,7 @@ The `shuffle_xor()` primitive enables powerful butterfly communication patterns 
 ```mojo
 offset = WARP_SIZE // 2
 while offset > 0:
-    neighbor_val = shuffle_xor(current_val, offset)
+    neighbor_val = shuffle_xor(current_val, UInt32(offset))
     current_val = operation(current_val, neighbor_val)
     offset //= 2
 ```

--- a/book/src/puzzle_27/block_prefix_sum.md
+++ b/book/src/puzzle_27/block_prefix_sum.md
@@ -92,7 +92,7 @@ To classify a `Float32` value into bins:
 
 ```mojo
 my_value = input_data[global_i][0]  # Extract SIMD like in dot product
-bin_number = Int(floor(my_value * num_bins))
+bin_number = Int(floor(my_value * Float32(num_bins)))
 ```
 
 **Edge case handling**: Values exactly 1.0 would go to bin `NUM_BINS`, but you only have bins 0 to `NUM_BINS-1`. Use an `if` statement to clamp the maximum bin.
@@ -140,7 +140,7 @@ The last thread (not thread 0!) computes the total count:
 
 ```mojo
 if local_i == tpb - 1:  # Last thread in block
-    total_count = offset[0] + belongs_to_target  # Inclusive = exclusive + own contribution
+    total_count = offset[0] + Int32(belongs_to_target)  # Inclusive = exclusive + own contribution
     count_output[0] = total_count
 ```
 
@@ -322,7 +322,7 @@ Result: [0.00, 0.01, 0.02, ..., 0.12, ???, ???, ...] // Perfectly packed!
 ```
 Last thread computes total (not thread 0!):
   if local_i == tpb - 1:  // Thread 127 in our case
-      total = write_offset[0] + belongs_to_target  // Inclusive sum formula
+      total = write_offset[0] + Int32(belongs_to_target)  // Inclusive sum formula
       count_output[0] = total
 ```
 

--- a/book/src/puzzle_29/memory_barrier.md
+++ b/book/src/puzzle_29/memory_barrier.md
@@ -327,7 +327,7 @@ stencil_count = 0
 for neighbor in valid_neighbors:
     stencil_sum += buffer[neighbor]
     stencil_count += 1
-result[i] = stencil_sum / stencil_count
+result[i] = stencil_sum / Float32(stencil_count)
 ```
 
 ## **Buffer role alternation**

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,7 +40,7 @@ system-requirements = { macos = "15.0" }
 [dependencies]
 python = "==3.12"
 mojo = "<1.0.0" # includes `mojo-compiler`, lsp, debugger, formatter etc.
-max = "==26.3.0.dev2026032405"
+max = "==26.3.0.dev2026033105"
 bash = ">=5.2.21,<6"
 manim = ">=0.18.1,<0.19"
 mdbook = ">=0.4.48,<0.5"

--- a/problems/p01/p01.mojo
+++ b/problems/p01/p01.mojo
@@ -29,7 +29,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[add_10, add_10](
             out,
@@ -43,7 +43,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = Float32(i + 10)
+            expected[i] = Scalar[dtype](i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/problems/p01/p01.mojo
+++ b/problems/p01/p01.mojo
@@ -29,7 +29,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[add_10, add_10](
             out,
@@ -43,7 +43,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = i + 10
+            expected[i] = Float32(i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/problems/p02/p02.mojo
+++ b/problems/p02/p02.mojo
@@ -34,8 +34,8 @@ def main() raises:
         expected.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i
-                b_host[i] = i
+                a_host[i] = Float32(i)
+                b_host[i] = Float32(i)
                 expected[i] = a_host[i] + b_host[i]
 
         ctx.enqueue_function[add, add](

--- a/problems/p02/p02.mojo
+++ b/problems/p02/p02.mojo
@@ -34,8 +34,8 @@ def main() raises:
         expected.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
-                b_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
+                b_host[i] = Scalar[dtype](i)
                 expected[i] = a_host[i] + b_host[i]
 
         ctx.enqueue_function[add, add](

--- a/problems/p03/p03.mojo
+++ b/problems/p03/p03.mojo
@@ -30,7 +30,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[add_10_guard, add_10_guard](
             out,
@@ -45,7 +45,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = i + 10
+            expected[i] = Float32(i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/problems/p03/p03.mojo
+++ b/problems/p03/p03.mojo
@@ -30,7 +30,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[add_10_guard, add_10_guard](
             out,
@@ -45,7 +45,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = Float32(i + 10)
+            expected[i] = Scalar[dtype](i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/problems/p03/p03.mojo
+++ b/problems/p03/p03.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_guard(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var i = thread_idx.x
     # FILL ME IN (roughly 2 lines)
@@ -35,7 +35,7 @@ def main() raises:
         ctx.enqueue_function[add_10_guard, add_10_guard](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p04/p04.mojo
+++ b/problems/p04/p04.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_2d(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -41,7 +41,7 @@ def main() raises:
         ctx.enqueue_function[add_10_2d, add_10_2d](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p04/p04.mojo
+++ b/problems/p04/p04.mojo
@@ -35,7 +35,7 @@ def main() raises:
             # row-major
             for i in range(SIZE):
                 for j in range(SIZE):
-                    a_host[i * SIZE + j] = i * SIZE + j
+                    a_host[i * SIZE + j] = Float32(i * SIZE + j)
                     expected[i * SIZE + j] = a_host[i * SIZE + j] + 10
 
         ctx.enqueue_function[add_10_2d, add_10_2d](

--- a/problems/p04/p04.mojo
+++ b/problems/p04/p04.mojo
@@ -35,7 +35,7 @@ def main() raises:
             # row-major
             for i in range(SIZE):
                 for j in range(SIZE):
-                    a_host[i * SIZE + j] = Float32(i * SIZE + j)
+                    a_host[i * SIZE + j] = Scalar[dtype](i * SIZE + j)
                     expected[i * SIZE + j] = a_host[i * SIZE + j] + 10
 
         ctx.enqueue_function[add_10_2d, add_10_2d](

--- a/problems/p04/p04_layout_tensor.mojo
+++ b/problems/p04/p04_layout_tensor.mojo
@@ -38,7 +38,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
                 expected[i] = a_host[i] + 10
 
         var a_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](a)

--- a/problems/p04/p04_layout_tensor.mojo
+++ b/problems/p04/p04_layout_tensor.mojo
@@ -38,7 +38,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
                 expected[i] = a_host[i] + 10
 
         var a_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](a)

--- a/problems/p04/p04_layout_tensor.mojo
+++ b/problems/p04/p04_layout_tensor.mojo
@@ -14,7 +14,7 @@ comptime layout = Layout.row_major(SIZE, SIZE)
 def add_10_2d(
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -46,7 +46,7 @@ def main() raises:
         ctx.enqueue_function[add_10_2d, add_10_2d](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p05/p05.mojo
+++ b/problems/p05/p05.mojo
@@ -34,8 +34,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i + 1
-                b_host[i] = i * 10
+                a_host[i] = Float32(i + 1)
+                b_host[i] = Float32(i * 10)
 
             for i in range(SIZE):
                 for j in range(SIZE):

--- a/problems/p05/p05.mojo
+++ b/problems/p05/p05.mojo
@@ -34,8 +34,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i * 10)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i * 10)
 
             for i in range(SIZE):
                 for j in range(SIZE):

--- a/problems/p05/p05.mojo
+++ b/problems/p05/p05.mojo
@@ -14,7 +14,7 @@ def broadcast_add(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -45,7 +45,7 @@ def main() raises:
             out,
             a,
             b,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p05/p05_layout_tensor.mojo
+++ b/problems/p05/p05_layout_tensor.mojo
@@ -48,8 +48,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i * 10)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i * 10)
 
             for i in range(SIZE):
                 for j in range(SIZE):

--- a/problems/p05/p05_layout_tensor.mojo
+++ b/problems/p05/p05_layout_tensor.mojo
@@ -21,7 +21,7 @@ def broadcast_add[
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, a_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, b_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -63,7 +63,7 @@ def main() raises:
             out_tensor,
             a_tensor,
             b_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p05/p05_layout_tensor.mojo
+++ b/problems/p05/p05_layout_tensor.mojo
@@ -48,8 +48,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i + 1
-                b_host[i] = i * 10
+                a_host[i] = Float32(i + 1)
+                b_host[i] = Float32(i * 10)
 
             for i in range(SIZE):
                 for j in range(SIZE):

--- a/problems/p06/p06.mojo
+++ b/problems/p06/p06.mojo
@@ -30,7 +30,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[add_10_blocks, add_10_blocks](
             out,
@@ -46,7 +46,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = Float32(i + 10)
+            expected[i] = Scalar[dtype](i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/problems/p06/p06.mojo
+++ b/problems/p06/p06.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_blocks(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var i = block_dim.x * block_idx.x + thread_idx.x
     # FILL ME IN (roughly 2 lines)
@@ -35,7 +35,7 @@ def main() raises:
         ctx.enqueue_function[add_10_blocks, add_10_blocks](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p06/p06.mojo
+++ b/problems/p06/p06.mojo
@@ -30,7 +30,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[add_10_blocks, add_10_blocks](
             out,
@@ -46,7 +46,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = i + 10
+            expected[i] = Float32(i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/problems/p07/p07.mojo
+++ b/problems/p07/p07.mojo
@@ -36,8 +36,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = Float32(k)
-                    expected[k] = Float32(k + 10)
+                    a_host[k] = Scalar[dtype](k)
+                    expected[k] = Scalar[dtype](k + 10)
 
         ctx.enqueue_function[add_10_blocks_2d, add_10_blocks_2d](
             out,

--- a/problems/p07/p07.mojo
+++ b/problems/p07/p07.mojo
@@ -36,8 +36,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = k
-                    expected[k] = k + 10
+                    a_host[k] = Float32(k)
+                    expected[k] = Float32(k + 10)
 
         ctx.enqueue_function[add_10_blocks_2d, add_10_blocks_2d](
             out,

--- a/problems/p07/p07.mojo
+++ b/problems/p07/p07.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_blocks_2d(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = block_dim.y * block_idx.y + thread_idx.y
     var col = block_dim.x * block_idx.x + thread_idx.x
@@ -42,7 +42,7 @@ def main() raises:
         ctx.enqueue_function[add_10_blocks_2d, add_10_blocks_2d](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p07/p07_layout_tensor.mojo
+++ b/problems/p07/p07_layout_tensor.mojo
@@ -18,7 +18,7 @@ def add_10_blocks_2d[
 ](
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, a_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = block_dim.y * block_idx.y + thread_idx.y
     var col = block_dim.x * block_idx.x + thread_idx.x
@@ -53,7 +53,7 @@ def main() raises:
         ctx.enqueue_function[kernel, kernel](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p07/p07_layout_tensor.mojo
+++ b/problems/p07/p07_layout_tensor.mojo
@@ -44,8 +44,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = Float32(k)
-                    expected_buf[k] = Float32(k + 10)
+                    a_host[k] = Scalar[dtype](k)
+                    expected_buf[k] = Scalar[dtype](k + 10)
 
         var a_tensor = LayoutTensor[dtype, a_layout, ImmutAnyOrigin](a)
 

--- a/problems/p07/p07_layout_tensor.mojo
+++ b/problems/p07/p07_layout_tensor.mojo
@@ -44,8 +44,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = k
-                    expected_buf[k] = k + 10
+                    a_host[k] = Float32(k)
+                    expected_buf[k] = Float32(k + 10)
 
         var a_tensor = LayoutTensor[dtype, a_layout, ImmutAnyOrigin](a)
 

--- a/problems/p08/p08.mojo
+++ b/problems/p08/p08.mojo
@@ -15,7 +15,7 @@ comptime dtype = DType.float32
 def add_10_shared(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var shared = stack_allocation[
         TPB,
@@ -47,7 +47,7 @@ def main() raises:
         ctx.enqueue_function[add_10_shared, add_10_shared](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p08/p08_layout_tensor.mojo
+++ b/problems/p08/p08_layout_tensor.mojo
@@ -18,7 +18,7 @@ def add_10_shared_layout_tensor[
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     # Allocate shared memory using LayoutTensor with explicit address_space
     var shared = LayoutTensor[
@@ -56,7 +56,7 @@ def main() raises:
         ctx.enqueue_function[kernel, kernel](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p09/p09.mojo
+++ b/problems/p09/p09.mojo
@@ -137,7 +137,7 @@ def main() raises:
             # Initialize input [0, 1, 2, 3]
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = Float32(i)
+                    input_host[i] = Scalar[dtype](i)
 
             # Create LayoutTensors for structured access
             input_tensor = LayoutTensor[dtype, vector_layout, ImmutAnyOrigin](
@@ -214,7 +214,7 @@ def main() raises:
             # Initialize input data [1, 2, 3, 4]
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = Float32(i + 1)
+                    input_host[i] = Scalar[dtype](i + 1)
 
             # Create LayoutTensors
             input_tensor = LayoutTensor[dtype, vector_layout, ImmutAnyOrigin](

--- a/problems/p09/p09.mojo
+++ b/problems/p09/p09.mojo
@@ -137,7 +137,7 @@ def main() raises:
             # Initialize input [0, 1, 2, 3]
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = i
+                    input_host[i] = Float32(i)
 
             # Create LayoutTensors for structured access
             input_tensor = LayoutTensor[dtype, vector_layout, ImmutAnyOrigin](
@@ -214,7 +214,7 @@ def main() raises:
             # Initialize input data [1, 2, 3, 4]
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = i + 1
+                    input_host[i] = Float32(i + 1)
 
             # Create LayoutTensors
             input_tensor = LayoutTensor[dtype, vector_layout, ImmutAnyOrigin](

--- a/problems/p10/p10.mojo
+++ b/problems/p10/p10.mojo
@@ -79,7 +79,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a).reshape[
             layout
@@ -89,7 +89,7 @@ def main() raises:
             print("Running memory bug example (bounds checking issue)...")
             # Fill expected values directly since it's a HostBuffer
             for i in range(SIZE * SIZE):
-                expected[i] = i + 10
+                expected[i] = Float32(i + 10)
 
             ctx.enqueue_function[add_10_2d, add_10_2d](
                 out_tensor,

--- a/problems/p10/p10.mojo
+++ b/problems/p10/p10.mojo
@@ -79,7 +79,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a).reshape[
             layout
@@ -89,7 +89,7 @@ def main() raises:
             print("Running memory bug example (bounds checking issue)...")
             # Fill expected values directly since it's a HostBuffer
             for i in range(SIZE * SIZE):
-                expected[i] = Float32(i + 10)
+                expected[i] = Scalar[dtype](i + 10)
 
             ctx.enqueue_function[add_10_2d, add_10_2d](
                 out_tensor,

--- a/problems/p10/p10.mojo
+++ b/problems/p10/p10.mojo
@@ -17,7 +17,7 @@ comptime layout = Layout.row_major(SIZE, SIZE)
 def shared_memory_race(
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -45,7 +45,7 @@ def shared_memory_race(
 def add_10_2d(
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -94,7 +94,7 @@ def main() raises:
             ctx.enqueue_function[add_10_2d, add_10_2d](
                 out_tensor,
                 a_tensor,
-                UInt(SIZE),
+                SIZE,
                 grid_dim=BLOCKS_PER_GRID,
                 block_dim=THREADS_PER_BLOCK,
             )
@@ -123,7 +123,7 @@ def main() raises:
             ctx.enqueue_function[shared_memory_race, shared_memory_race](
                 out_tensor,
                 a_tensor,
-                UInt(SIZE),
+                SIZE,
                 grid_dim=BLOCKS_PER_GRID,
                 block_dim=THREADS_PER_BLOCK,
             )

--- a/problems/p11/p11.mojo
+++ b/problems/p11/p11.mojo
@@ -38,7 +38,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[pooling, pooling](
             out,

--- a/problems/p11/p11.mojo
+++ b/problems/p11/p11.mojo
@@ -38,7 +38,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[pooling, pooling](
             out,

--- a/problems/p11/p11.mojo
+++ b/problems/p11/p11.mojo
@@ -15,7 +15,7 @@ comptime dtype = DType.float32
 def pooling(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var shared = stack_allocation[
         TPB,
@@ -43,7 +43,7 @@ def main() raises:
         ctx.enqueue_function[pooling, pooling](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p11/p11_layout_tensor.mojo
+++ b/problems/p11/p11_layout_tensor.mojo
@@ -45,7 +45,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/problems/p11/p11_layout_tensor.mojo
+++ b/problems/p11/p11_layout_tensor.mojo
@@ -18,7 +18,7 @@ def pooling[
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     # Allocate shared memory using tensor builder
     var shared = LayoutTensor[
@@ -53,7 +53,7 @@ def main() raises:
         ctx.enqueue_function[pooling[layout], pooling[layout]](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p11/p11_layout_tensor.mojo
+++ b/problems/p11/p11_layout_tensor.mojo
@@ -45,7 +45,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/problems/p12/p12.mojo
+++ b/problems/p12/p12.mojo
@@ -35,8 +35,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
-                b_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
+                b_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[dot_product, dot_product](
             out,

--- a/problems/p12/p12.mojo
+++ b/problems/p12/p12.mojo
@@ -35,8 +35,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i
-                b_host[i] = i
+                a_host[i] = Float32(i)
+                b_host[i] = Float32(i)
 
         ctx.enqueue_function[dot_product, dot_product](
             out,

--- a/problems/p12/p12.mojo
+++ b/problems/p12/p12.mojo
@@ -16,7 +16,7 @@ def dot_product(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     # FILL ME IN (roughly 13 lines)
     ...
@@ -42,7 +42,7 @@ def main() raises:
             out,
             a,
             b,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p12/p12_layout_tensor.mojo
+++ b/problems/p12/p12_layout_tensor.mojo
@@ -22,7 +22,7 @@ def dot_product[
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     # FILL ME IN (roughly 13 lines)
     ...
@@ -54,7 +54,7 @@ def main() raises:
             out_tensor,
             a_tensor,
             b_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p12/p12_layout_tensor.mojo
+++ b/problems/p12/p12_layout_tensor.mojo
@@ -42,8 +42,8 @@ def main() raises:
 
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
-                b_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
+                b_host[i] = Scalar[dtype](i)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/problems/p12/p12_layout_tensor.mojo
+++ b/problems/p12/p12_layout_tensor.mojo
@@ -42,8 +42,8 @@ def main() raises:
 
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i
-                b_host[i] = i
+                a_host[i] = Float32(i)
+                b_host[i] = Float32(i)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/problems/p13/p13.mojo
+++ b/problems/p13/p13.mojo
@@ -68,11 +68,11 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         with b.map_to_host() as b_host:
             for i in range(conv):
-                b_host[i] = i
+                b_host[i] = Float32(i)
 
         if len(argv()) != 2 or argv()[1] not in [
             "--simple",

--- a/problems/p13/p13.mojo
+++ b/problems/p13/p13.mojo
@@ -68,11 +68,11 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         with b.map_to_host() as b_host:
             for i in range(conv):
-                b_host[i] = Float32(i)
+                b_host[i] = Scalar[dtype](i)
 
         if len(argv()) != 2 or argv()[1] not in [
             "--simple",

--- a/problems/p13/p13.mojo
+++ b/problems/p13/p13.mojo
@@ -25,7 +25,7 @@ def conv_1d_simple[
     b: LayoutTensor[dtype, conv_layout, ImmutAnyOrigin],
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
-    var local_i = Int(thread_idx.x)
+    var local_i = thread_idx.x
     # FILL ME IN (roughly 14 lines)
 
 
@@ -48,8 +48,8 @@ def conv_1d_block_boundary[
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, conv_layout, ImmutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     # FILL ME IN (roughly 18 lines)
 
 

--- a/problems/p14/p14.mojo
+++ b/problems/p14/p14.mojo
@@ -88,7 +88,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         if use_simple:
             a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/problems/p14/p14.mojo
+++ b/problems/p14/p14.mojo
@@ -20,7 +20,7 @@ def prefix_sum_simple[
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
@@ -44,7 +44,7 @@ def prefix_sum_local_phase[
 ](
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
@@ -54,7 +54,7 @@ def prefix_sum_local_phase[
 # Kernel 2: Add block sums to their respective blocks
 def prefix_sum_block_sum_phase[
     layout: Layout
-](output: LayoutTensor[dtype, layout, MutAnyOrigin], size: UInt):
+](output: LayoutTensor[dtype, layout, MutAnyOrigin], size: Int):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     # FILL ME IN (roughly 3 lines)
 
@@ -98,7 +98,7 @@ def main() raises:
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
-                UInt(size),
+                size,
                 grid_dim=BLOCKS_PER_GRID,
                 block_dim=THREADS_PER_BLOCK,
             )
@@ -114,7 +114,7 @@ def main() raises:
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
-                UInt(size),
+                size,
                 grid_dim=BLOCKS_PER_GRID_2,
                 block_dim=THREADS_PER_BLOCK_2,
             )
@@ -126,7 +126,7 @@ def main() raises:
             comptime kernel2 = prefix_sum_block_sum_phase[extended_layout]
             ctx.enqueue_function[kernel2, kernel2](
                 out_tensor,
-                UInt(size),
+                size,
                 grid_dim=BLOCKS_PER_GRID_2,
                 block_dim=THREADS_PER_BLOCK_2,
             )

--- a/problems/p14/p14.mojo
+++ b/problems/p14/p14.mojo
@@ -88,7 +88,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         if use_simple:
             a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/problems/p15/p15.mojo
+++ b/problems/p15/p15.mojo
@@ -42,7 +42,7 @@ def main() raises:
         with inp.map_to_host() as inp_host:
             for row in range(BATCH):
                 for col in range(SIZE):
-                    inp_host[row * SIZE + col] = row * SIZE + col
+                    inp_host[row * SIZE + col] = Float32(row * SIZE + col)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var inp_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](inp)

--- a/problems/p15/p15.mojo
+++ b/problems/p15/p15.mojo
@@ -42,7 +42,7 @@ def main() raises:
         with inp.map_to_host() as inp_host:
             for row in range(BATCH):
                 for col in range(SIZE):
-                    inp_host[row * SIZE + col] = Float32(row * SIZE + col)
+                    inp_host[row * SIZE + col] = Scalar[dtype](row * SIZE + col)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var inp_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](inp)

--- a/problems/p15/p15.mojo
+++ b/problems/p15/p15.mojo
@@ -22,7 +22,7 @@ def axis_sum[
 ](
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
@@ -51,7 +51,7 @@ def main() raises:
         ctx.enqueue_function[kernel, kernel](
             out_tensor,
             inp_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/problems/p16/p16.mojo
+++ b/problems/p16/p16.mojo
@@ -99,9 +99,7 @@ def main() raises:
                     var val = row * size + col
                     # row major: placing elements row by row
                     inp1_host[row * size + col] = Scalar[dtype](val)
-                    inp2_host[row * size + col] = Scalar[dtype](2.0) * Scalar[
-                        dtype
-                    ](val)
+                    inp2_host[row * size + col] = Scalar[dtype](2.0 * val)
 
             # inp1 @ inp2.T
             for i in range(size):

--- a/problems/p16/p16.mojo
+++ b/problems/p16/p16.mojo
@@ -17,7 +17,7 @@ comptime layout = Layout.row_major(SIZE, SIZE)
 
 
 def naive_matmul[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
@@ -33,7 +33,7 @@ def naive_matmul[
 
 # ANCHOR: single_block_matmul
 def single_block_matmul[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
@@ -56,7 +56,7 @@ comptime layout_tiled = Layout.row_major(SIZE_TILED, SIZE_TILED)
 
 
 def matmul_tiled[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout_tiled, MutAnyOrigin],
     a: LayoutTensor[dtype, layout_tiled, ImmutAnyOrigin],
@@ -114,7 +114,7 @@ def main() raises:
         var b_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](inp2)
 
         if argv()[1] == "--naive":
-            comptime kernel = naive_matmul[layout, UInt(SIZE)]
+            comptime kernel = naive_matmul[layout, SIZE]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
@@ -123,7 +123,7 @@ def main() raises:
                 block_dim=THREADS_PER_BLOCK,
             )
         elif argv()[1] == "--single-block":
-            comptime kernel = single_block_matmul[layout, UInt(SIZE)]
+            comptime kernel = single_block_matmul[layout, SIZE]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
@@ -143,7 +143,7 @@ def main() raises:
                 dtype, layout_tiled, ImmutAnyOrigin
             ](inp2)
 
-            comptime kernel = matmul_tiled[layout_tiled, UInt(SIZE_TILED)]
+            comptime kernel = matmul_tiled[layout_tiled, SIZE_TILED]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor_tiled,
                 a_tensor_tiled,

--- a/problems/p16/p16.mojo
+++ b/problems/p16/p16.mojo
@@ -98,8 +98,10 @@ def main() raises:
                 for col in range(size):
                     var val = row * size + col
                     # row major: placing elements row by row
-                    inp1_host[row * size + col] = Float32(val)
-                    inp2_host[row * size + col] = Float32(2.0) * Float32(val)
+                    inp1_host[row * size + col] = Scalar[dtype](val)
+                    inp2_host[row * size + col] = Scalar[dtype](2.0) * Scalar[
+                        dtype
+                    ](val)
 
             # inp1 @ inp2.T
             for i in range(size):

--- a/problems/p16/p16.mojo
+++ b/problems/p16/p16.mojo
@@ -98,8 +98,8 @@ def main() raises:
                 for col in range(size):
                     var val = row * size + col
                     # row major: placing elements row by row
-                    inp1_host[row * size + col] = val
-                    inp2_host[row * size + col] = Float32(2.0) * val
+                    inp1_host[row * size + col] = Float32(val)
+                    inp2_host[row * size + col] = Float32(2.0) * Float32(val)
 
             # inp1 @ inp2.T
             for i in range(size):

--- a/problems/p17/op/conv1d.mojo
+++ b/problems/p17/op/conv1d.mojo
@@ -20,8 +20,8 @@ def conv1d_kernel[
     input: LayoutTensor[dtype, in_layout, MutAnyOrigin],
     kernel: LayoutTensor[dtype, conv_layout, MutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     # first: need to account for padding
     var shared_a = LayoutTensor[
         dtype,

--- a/problems/p18/test/test_softmax.mojo
+++ b/problems/p18/test/test_softmax.mojo
@@ -27,7 +27,7 @@ def test_softmax() raises:
         # Initialize input with more reasonable values
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
-                inp_host[i] = Float32(i)
+                inp_host[i] = Scalar[dtype](i)
 
             print("Input values:")
             for i in range(SIZE):

--- a/problems/p19/op/attention.mojo
+++ b/problems/p19/op/attention.mojo
@@ -42,14 +42,14 @@ def matmul_idiomatic_tiled[
     b: LayoutTensor[dtype, b_layout, MutAnyOrigin],
 ):
     """Updated idiomatic tiled matrix multiplication from p16."""
-    var local_row = Int(thread_idx.y)
-    var local_col = Int(thread_idx.x)
-    var tiled_row = Int(block_idx.y) * MATMUL_BLOCK_DIM_XY + local_row
-    var tiled_col = Int(block_idx.x) * MATMUL_BLOCK_DIM_XY + local_col
+    var local_row = thread_idx.y
+    var local_col = thread_idx.x
+    var tiled_row = block_idx.y * MATMUL_BLOCK_DIM_XY + local_row
+    var tiled_col = block_idx.x * MATMUL_BLOCK_DIM_XY + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
     var out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-        Int(block_idx.y), Int(block_idx.x)
+        block_idx.y, block_idx.x
     )
     var a_shared = LayoutTensor[
         dtype,
@@ -77,10 +77,10 @@ def matmul_idiomatic_tiled[
     ):
         # Get tiles from A and B matrices
         var a_tile = a.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            Int(block_idx.y), idx
+            block_idx.y, idx
         )
         var b_tile = b.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            idx, Int(block_idx.x)
+            idx, block_idx.x
         )
 
         # Asynchronously copy tiles to shared memory with consistent orientation
@@ -158,7 +158,7 @@ def softmax_gpu_kernel[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(thread_idx.x)
+    var global_i = thread_idx.x
 
     # Initialize out-of-bounds (shared_max[local_i], global_i >= input_size) shared memory addresses to the minimum
     # finite value for dtype, ensuring that if these elements are accessed in the parallel max reduction below they

--- a/problems/p20/op/conv1d.mojo
+++ b/problems/p20/op/conv1d.mojo
@@ -23,8 +23,8 @@ def conv1d_kernel[
     input: LayoutTensor[dtype, in_layout, MutAnyOrigin],
     kernel: LayoutTensor[dtype, conv_layout, MutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     # first: need to account for padding
     var shared_a = LayoutTensor[
         dtype,

--- a/problems/p21/op/embedding.mojo
+++ b/problems/p21/op/embedding.mojo
@@ -33,7 +33,7 @@ def embedding_kernel_coalesced[
     """
 
     # Simple 1D indexing - each thread = one output element
-    var global_idx = Int(block_idx.x * block_dim.x + thread_idx.x)
+    var global_idx = block_idx.x * block_dim.x + thread_idx.x
     var total_elements = batch_size * seq_len * embed_dim
 
     if global_idx >= total_elements:
@@ -77,8 +77,8 @@ def embedding_kernel_2d[
     """
 
     # 2D grid indexing
-    var batch_seq_idx = Int(block_idx.x * block_dim.x + thread_idx.x)
-    var embed_idx = Int(block_idx.y * block_dim.y + thread_idx.y)
+    var batch_seq_idx = block_idx.x * block_dim.x + thread_idx.x
+    var embed_idx = block_idx.y * block_dim.y + thread_idx.y
     var total_positions = batch_size * seq_len
 
     if batch_seq_idx >= total_positions or embed_idx >= embed_dim:

--- a/problems/p22/op/layernorm_linear.mojo
+++ b/problems/p22/op/layernorm_linear.mojo
@@ -149,8 +149,8 @@ def layernorm_kernel[
 def transpose_kernel[
     layout_in: Layout,
     layout_out: Layout,
-    rows: UInt,
-    cols: UInt,
+    rows: Int,
+    cols: Int,
     dtype: DType = DType.float32,
 ](
     output: LayoutTensor[dtype, layout_out, MutAnyOrigin],
@@ -481,8 +481,8 @@ struct LayerNormLinearCustomOp:
                 comptime kernel2 = transpose_kernel[
                     weight_layout,
                     transposed_weight_tensor.layout,
-                    UInt(output_dim),
-                    UInt(hidden_dim),
+                    output_dim,
+                    hidden_dim,
                 ]
                 gpu_ctx.enqueue_function[kernel2, kernel2](
                     transposed_weight_tensor,

--- a/problems/p22/op/layernorm_linear.mojo
+++ b/problems/p22/op/layernorm_linear.mojo
@@ -35,12 +35,12 @@ def matmul_idiomatic_tiled[
     """Idiomatic tiled matrix multiplication from p19."""
     var local_row = thread_idx.y
     var local_col = thread_idx.x
-    var tiled_row = Int(block_idx.y * MATMUL_BLOCK_DIM_XY + local_row)
-    var tiled_col = Int(block_idx.x * MATMUL_BLOCK_DIM_XY + local_col)
+    var tiled_row = block_idx.y * MATMUL_BLOCK_DIM_XY + local_row
+    var tiled_col = block_idx.x * MATMUL_BLOCK_DIM_XY + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
     var out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-        Int(block_idx.y), Int(block_idx.x)
+        block_idx.y, block_idx.x
     )
     var a_shared = LayoutTensor[
         dtype,
@@ -68,10 +68,10 @@ def matmul_idiomatic_tiled[
     ):
         # Get tiles from A and B matrices
         var a_tile = a.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            Int(block_idx.y), idx
+            block_idx.y, idx
         )
         var b_tile = b.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            idx, Int(block_idx.x)
+            idx, block_idx.x
         )
 
         # Asynchronously copy tiles to shared memory with consistent orientation
@@ -124,9 +124,9 @@ def layernorm_kernel[
     ln_weight: LayoutTensor[dtype, ln_params_layout, ImmutAnyOrigin],
     ln_bias: LayoutTensor[dtype, ln_params_layout, ImmutAnyOrigin],
 ):
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
-    var hidden_idx = Int(thread_idx.x)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
+    var hidden_idx = thread_idx.x
 
     if (
         batch_idx >= batch_size
@@ -203,9 +203,9 @@ def add_bias_kernel[
     bias: LayoutTensor[dtype, bias_layout, ImmutAnyOrigin],
 ):
     """Simple bias addition."""
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
-    var out_idx = Int(thread_idx.x)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
+    var out_idx = thread_idx.x
 
     if batch_idx >= batch_size or seq_idx >= seq_len or out_idx >= output_dim:
         return
@@ -241,8 +241,8 @@ def minimal_fused_kernel[
     """
     # Grid: (batch_size, seq_len) - one thread block per sequence position
     # Block: (1,) - single thread per sequence position to avoid redundant computation
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
 
     if batch_idx >= batch_size or seq_idx >= seq_len:
         return
@@ -290,8 +290,8 @@ def minimal_fused_kernel_backward[
     """
     # Grid: (batch_size, seq_len) - one thread per sequence position
     # Block: (1,) - single thread per sequence position
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
 
     if batch_idx >= batch_size or seq_idx >= seq_len:
         return

--- a/problems/p23/p23.mojo
+++ b/problems/p23/p23.mojo
@@ -181,8 +181,8 @@ def benchmark_elementwise_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout, MutAnyOrigin](
         a.unsafe_ptr()
@@ -222,8 +222,8 @@ def benchmark_tiled_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -257,8 +257,8 @@ def benchmark_manual_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -292,8 +292,8 @@ def benchmark_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -324,8 +324,8 @@ def main() raises:
 
     with a.map_to_host() as a_host, b.map_to_host() as b_host:
         for i in range(SIZE):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
             expected[i] = a_host[i] + b_host[i]
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())

--- a/problems/p23/p23.mojo
+++ b/problems/p23/p23.mojo
@@ -181,8 +181,8 @@ def benchmark_elementwise_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout, MutAnyOrigin](
         a.unsafe_ptr()
@@ -222,8 +222,8 @@ def benchmark_tiled_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -257,8 +257,8 @@ def benchmark_manual_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -292,8 +292,8 @@ def benchmark_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -324,8 +324,8 @@ def main() raises:
 
     with a.map_to_host() as a_host, b.map_to_host() as b_host:
         for i in range(SIZE):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
             expected[i] = a_host[i] + b_host[i]
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())

--- a/problems/p24/p24.mojo
+++ b/problems/p24/p24.mojo
@@ -139,7 +139,9 @@ def rand_int[
 ](buff: DeviceBuffer[dtype], min: Int = 0, max: Int = 100) raises:
     with buff.map_to_host() as buff_host:
         for i in range(size):
-            buff_host[i] = Scalar[dtype](Int(random_float64(Float64(min), Float64(max))))
+            buff_host[i] = Scalar[dtype](
+                Int(random_float64(Float64(min), Float64(max)))
+            )
 
 
 def check_result[

--- a/problems/p24/p24.mojo
+++ b/problems/p24/p24.mojo
@@ -47,8 +47,8 @@ def traditional_dot_product_p12_style[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     if global_i < size:
         shared[local_i] = (a[global_i] * b[global_i]).reduce_add()
@@ -79,7 +79,7 @@ def simple_warp_dot_product[
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     # FILL IN (6 lines at most)
 
 

--- a/problems/p24/p24.mojo
+++ b/problems/p24/p24.mojo
@@ -324,8 +324,8 @@ def main() raises:
 
             with a.map_to_host() as a_host, b.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = Float32(i)
-                    b_host[i] = Float32(i)
+                    a_host[i] = Scalar[dtype](i)
+                    b_host[i] = Scalar[dtype](i)
 
             if argv()[1] == "--traditional":
                 ctx.enqueue_function[

--- a/problems/p24/p24.mojo
+++ b/problems/p24/p24.mojo
@@ -139,7 +139,7 @@ def rand_int[
 ](buff: DeviceBuffer[dtype], min: Int = 0, max: Int = 100) raises:
     with buff.map_to_host() as buff_host:
         for i in range(size):
-            buff_host[i] = Int(random_float64(min, max))
+            buff_host[i] = Scalar[dtype](Int(random_float64(Float64(min), Float64(max))))
 
 
 def check_result[
@@ -322,8 +322,8 @@ def main() raises:
 
             with a.map_to_host() as a_host, b.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = i
-                    b_host[i] = i
+                    a_host[i] = Float32(i)
+                    b_host[i] = Float32(i)
 
             if argv()[1] == "--traditional":
                 ctx.enqueue_function[

--- a/problems/p25/p25.mojo
+++ b/problems/p25/p25.mojo
@@ -24,7 +24,7 @@ def neighbor_difference[
     Uses shuffle_down(val, 1) to get the next neighbor's value.
     Works across multiple blocks, each processing one warp worth of data.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     # FILL IN (roughly 7 lines)
@@ -50,7 +50,7 @@ def moving_average_3[
     Uses shuffle_down with offsets 1 and 2 to access neighbors.
     Works within warp boundaries across multiple blocks.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     # FILL IN (roughly 10 lines)
@@ -71,7 +71,7 @@ def broadcast_shuffle_coordination[
     Lane 0 computes block-local scaling factor, broadcasts it to all lanes in the warp.
     Each lane uses shuffle_down() for neighbor access and applies broadcast factor.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
     if global_i < size:
         var scale_factor: output.element_type = 0.0
@@ -93,7 +93,7 @@ def basic_broadcast[
     Basic broadcast: Lane 0 computes a block-local value, broadcasts it to all lanes.
     Each lane then uses this broadcast value in its own computation.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
     if global_i < size:
         var broadcast_value: output.element_type = 0.0
@@ -115,7 +115,7 @@ def conditional_broadcast[
     Conditional broadcast: Lane 0 makes a decision based on block-local data, broadcasts it to all lanes.
     All lanes apply different logic based on the broadcast decision.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
     if global_i < size:
         var decision_value: output.element_type = 0.0

--- a/problems/p25/p25.mojo
+++ b/problems/p25/p25.mojo
@@ -143,7 +143,7 @@ def test_neighbor_difference() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i * i)
+                input_host[i] = Scalar[dtype](i * i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -166,7 +166,7 @@ def test_neighbor_difference() raises:
 
         # Create expected results: differences of squares should be odd numbers
         for i in range(SIZE - 1):
-            expected_buf[i] = Float32((i + 1) * (i + 1) - i * i)
+            expected_buf[i] = Scalar[dtype]((i + 1) * (i + 1) - i * i)
         expected_buf[
             SIZE - 1
         ] = 0  # Last element should be 0 (no valid neighbor)
@@ -191,7 +191,7 @@ def test_moving_average() raises:
         with input_buf.map_to_host() as input_host:
             input_host[0] = 1
             for i in range(1, SIZE_2):
-                input_host[i] = input_host[i - 1] + Float32(i + 1)
+                input_host[i] = input_host[i - 1] + Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -259,9 +259,9 @@ def test_broadcast_shuffle_coordination() raises:
             # Create pattern: [2, 4, 6, 8, 1, 3, 5, 7, ...]
             for i in range(SIZE):
                 if i < 4:
-                    input_host[i] = Float32((i + 1) * 2)
+                    input_host[i] = Scalar[dtype]((i + 1) * 2)
                 else:
-                    input_host[i] = Float32(((i - 4) % 4) * 2 + 1)
+                    input_host[i] = Scalar[dtype](((i - 4) % 4) * 2 + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -285,7 +285,7 @@ def test_broadcast_shuffle_coordination() raises:
         # Create expected results
         with input_buf.map_to_host() as input_host:
             # Lane 0 computes scale_factor from first 4 elements in block: (2+4+6+8)/4 = 5.0
-            var expected_scale = Float32(5.0)
+            var expected_scale = Scalar[dtype](5.0)
 
             for i in range(SIZE):
                 if i < SIZE - 1:
@@ -315,7 +315,7 @@ def test_basic_broadcast() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -339,7 +339,7 @@ def test_basic_broadcast() raises:
         # Create expected results
         with input_buf.map_to_host() as input_host:
             # Lane 0 computes broadcast_value from first 4 elements: 1+2+3+4 = 10
-            var expected_broadcast = Float32(10.0)
+            var expected_broadcast = Scalar[dtype](10.0)
             for i in range(SIZE):
                 expected_buf[i] = expected_broadcast + input_host[i]
 
@@ -365,14 +365,14 @@ def test_conditional_broadcast() raises:
         with input_buf.map_to_host() as input_host:
             # Create pattern with known max
             var test_values = [
-                Float32(3.0),
-                Float32(1.0),
-                Float32(7.0),
-                Float32(2.0),
-                Float32(9.0),
-                Float32(4.0),
-                Float32(6.0),
-                Float32(8.0),
+                Scalar[dtype](3.0),
+                Scalar[dtype](1.0),
+                Scalar[dtype](7.0),
+                Scalar[dtype](2.0),
+                Scalar[dtype](9.0),
+                Scalar[dtype](4.0),
+                Scalar[dtype](6.0),
+                Scalar[dtype](8.0),
             ]
             for i in range(SIZE):
                 input_host[i] = test_values[i % len(test_values)]
@@ -399,7 +399,7 @@ def test_conditional_broadcast() raises:
         # Create expected results
         with input_buf.map_to_host() as input_host:
             # Lane 0 finds max of first 8 elements in block: max(3,1,7,2,9,4,6,8) = 9.0, threshold = 4.5
-            var expected_max = Float32(9.0)
+            var expected_max = Scalar[dtype](9.0)
             var threshold = expected_max / 2.0
             for i in range(SIZE):
                 if input_host[i] >= threshold:

--- a/problems/p25/p25.mojo
+++ b/problems/p25/p25.mojo
@@ -143,7 +143,7 @@ def test_neighbor_difference() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i * i
+                input_host[i] = Float32(i * i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -166,7 +166,7 @@ def test_neighbor_difference() raises:
 
         # Create expected results: differences of squares should be odd numbers
         for i in range(SIZE - 1):
-            expected_buf[i] = (i + 1) * (i + 1) - i * i
+            expected_buf[i] = Float32((i + 1) * (i + 1) - i * i)
         expected_buf[
             SIZE - 1
         ] = 0  # Last element should be 0 (no valid neighbor)
@@ -191,7 +191,7 @@ def test_moving_average() raises:
         with input_buf.map_to_host() as input_host:
             input_host[0] = 1
             for i in range(1, SIZE_2):
-                input_host[i] = input_host[i - 1] + i + 1
+                input_host[i] = input_host[i - 1] + Float32(i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -259,9 +259,9 @@ def test_broadcast_shuffle_coordination() raises:
             # Create pattern: [2, 4, 6, 8, 1, 3, 5, 7, ...]
             for i in range(SIZE):
                 if i < 4:
-                    input_host[i] = (i + 1) * 2
+                    input_host[i] = Float32((i + 1) * 2)
                 else:
-                    input_host[i] = ((i - 4) % 4) * 2 + 1
+                    input_host[i] = Float32(((i - 4) % 4) * 2 + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -315,7 +315,7 @@ def test_basic_broadcast() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i + 1
+                input_host[i] = Float32(i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf

--- a/problems/p26/p26.mojo
+++ b/problems/p26/p26.mojo
@@ -165,7 +165,7 @@ def test_butterfly_pair_swap() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i
+                input_host[i] = Float32(i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -191,10 +191,10 @@ def test_butterfly_pair_swap() raises:
         for i in range(SIZE):
             if i % 2 == 0:
                 # Even positions get odd values
-                expected_buf[i] = i + 1
+                expected_buf[i] = Float32(i + 1)
             else:
                 # Odd positions get even values
-                expected_buf[i] = i - 1
+                expected_buf[i] = Float32(i - 1)
 
         with output_buf.map_to_host() as output_host:
             print("output:", output_host)
@@ -214,7 +214,7 @@ def test_butterfly_parallel_max() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i * 2
+                input_host[i] = Float32(i * 2)
             # Make sure we have a clear maximum
             input_host[SIZE - 1] = 1000.0
 
@@ -260,9 +260,9 @@ def test_butterfly_conditional_max() raises:
             for i in range(SIZE_2):
                 if i < 9:
                     var values = [3, 1, 7, 2, 9, 4, 8, 5, 6]
-                    input_host[i] = values[i]
+                    input_host[i] = Float32(values[i])
                 else:
-                    input_host[i] = i % 10
+                    input_host[i] = Float32(i % 10)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -322,7 +322,7 @@ def test_warp_inclusive_prefix_sum() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i + 1
+                input_host[i] = Float32(i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -388,7 +388,7 @@ def test_warp_partition() raises:
                 13,
             ]
             for i in range(SIZE):
-                input_host[i] = test_values[i % len(test_values)]
+                input_host[i] = Float32(test_values[i % len(test_values)])
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf

--- a/problems/p26/p26.mojo
+++ b/problems/p26/p26.mojo
@@ -165,7 +165,7 @@ def test_butterfly_pair_swap() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i)
+                input_host[i] = Scalar[dtype](i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -191,10 +191,10 @@ def test_butterfly_pair_swap() raises:
         for i in range(SIZE):
             if i % 2 == 0:
                 # Even positions get odd values
-                expected_buf[i] = Float32(i + 1)
+                expected_buf[i] = Scalar[dtype](i + 1)
             else:
                 # Odd positions get even values
-                expected_buf[i] = Float32(i - 1)
+                expected_buf[i] = Scalar[dtype](i - 1)
 
         with output_buf.map_to_host() as output_host:
             print("output:", output_host)
@@ -214,7 +214,7 @@ def test_butterfly_parallel_max() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i * 2)
+                input_host[i] = Scalar[dtype](i * 2)
             # Make sure we have a clear maximum
             input_host[SIZE - 1] = 1000.0
 
@@ -260,9 +260,9 @@ def test_butterfly_conditional_max() raises:
             for i in range(SIZE_2):
                 if i < 9:
                     var values = [3, 1, 7, 2, 9, 4, 8, 5, 6]
-                    input_host[i] = Float32(values[i])
+                    input_host[i] = Scalar[dtype](values[i])
                 else:
-                    input_host[i] = Float32(i % 10)
+                    input_host[i] = Scalar[dtype](i % 10)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -322,7 +322,7 @@ def test_warp_inclusive_prefix_sum() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -366,7 +366,7 @@ def test_warp_partition() raises:
         output_buf.enqueue_fill(0)
 
         # Create test data: mix of values above and below pivot
-        var pivot_value = Float32(5.0)
+        var pivot_value = Scalar[dtype](5.0)
         with input_buf.map_to_host() as input_host:
             # Create: [3, 7, 1, 8, 2, 9, 4, 6, ...]
             var test_values = [
@@ -388,7 +388,7 @@ def test_warp_partition() raises:
                 13,
             ]
             for i in range(SIZE):
-                input_host[i] = Float32(test_values[i % len(test_values)])
+                input_host[i] = Scalar[dtype](test_values[i % len(test_values)])
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf

--- a/problems/p26/p26.mojo
+++ b/problems/p26/p26.mojo
@@ -25,7 +25,7 @@ def butterfly_pair_swap[
     Uses shuffle_xor(val, 1) to swap values within each pair.
     This is the foundation of butterfly network communication patterns.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     # FILL ME IN (4 lines)
 
@@ -47,7 +47,7 @@ def butterfly_parallel_max[
     This implements an efficient O(log n) parallel reduction algorithm that works
     for any WARP_SIZE (32, 64, etc.).
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     # FILL ME IN (roughly 7 lines)
 
@@ -73,7 +73,7 @@ def butterfly_conditional_max[
     in even-numbered lanes. Odd-numbered lanes store the minimum value seen.
     Demonstrates conditional logic combined with butterfly communication patterns.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = lane_id()
 
     if global_i < size:
@@ -113,7 +113,7 @@ def warp_inclusive_prefix_sum[
     NOTE: This implementation only works correctly within a single warp (WARP_SIZE threads).
     For multi-warp scenarios, additional coordination would be needed.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     # FILL ME IN (roughly 4 lines)
 
@@ -145,7 +145,7 @@ def warp_partition[
     Input:  [3, 7, 1, 8, 2, 9, 4, 6]
     var Result: [3, 1, 2, 4, 7, 8, 9, 6] (< pivot | >= pivot).
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     if global_i < size:
         var current_val = input[global_i]

--- a/problems/p27/p27.mojo
+++ b/problems/p27/p27.mojo
@@ -200,8 +200,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = Float32(i)
-                    b_host[i] = Float32(2 * i)
+                    a_host[i] = Scalar[dtype](i)
+                    b_host[i] = Scalar[dtype](2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)
@@ -245,8 +245,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = Float32(i)
-                    b_host[i] = Float32(2 * i)
+                    a_host[i] = Scalar[dtype](i)
+                    b_host[i] = Scalar[dtype](2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)
@@ -297,7 +297,7 @@ def main() raises:
                 for i in range(SIZE):
                     # Create values: 0.1, 0.2, 0.3, ..., cycling through bins
                     input_host[i] = (
-                        Float32(i % 80) / 100.0
+                        Scalar[dtype](i % 80) / 100.0
                     )  # Values [0.0, 0.79]
 
             print("Input sample:", end=" ")
@@ -317,9 +317,9 @@ def main() raises:
                     "=== Processing Bin",
                     target_bin,
                     "(range [",
-                    Float32(target_bin) / NUM_BINS,
+                    Scalar[dtype](target_bin) / NUM_BINS,
                     ",",
-                    Float32(target_bin + 1) / NUM_BINS,
+                    Scalar[dtype](target_bin + 1) / NUM_BINS,
                     ")) ===",
                 )
 
@@ -388,13 +388,13 @@ def main() raises:
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
                     # Create values cycling 1-8, mean will be 4.5
-                    value = Float32(
+                    value = Scalar[dtype](
                         (i % 8) + 1
                     )  # Values 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, ...
                     input_host[i] = value
                     sum_value += value
 
-            var mean_value = sum_value / Float32(SIZE)
+            var mean_value = sum_value / Scalar[dtype](SIZE)
 
             print("Input sample:", end=" ")
             with input_buf.map_to_host() as input_host:
@@ -439,7 +439,7 @@ def main() raises:
                 for i in range(SIZE):
                     output_sum += output_host[i]
 
-                var output_mean = output_sum / Float32(SIZE)
+                var output_mean = output_sum / Scalar[dtype](SIZE)
                 print("Output sum:", output_sum)
                 print("Output mean:", output_mean)
                 print(

--- a/problems/p27/p27.mojo
+++ b/problems/p27/p27.mojo
@@ -200,8 +200,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = i
-                    b_host[i] = 2 * i
+                    a_host[i] = Float32(i)
+                    b_host[i] = Float32(2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)
@@ -245,8 +245,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = i
-                    b_host[i] = 2 * i
+                    a_host[i] = Float32(i)
+                    b_host[i] = Float32(2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)

--- a/problems/p27/p27.mojo
+++ b/problems/p27/p27.mojo
@@ -28,8 +28,8 @@ def traditional_dot_product[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Each thread computes partial product
     if global_i < size:
@@ -74,7 +74,7 @@ def block_sum_dot_product[
     """Dot product using block.sum() - convenience function like warp.sum()!
     Replaces manual shared memory + barriers + tree reduction with one line."""
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # FILL IN (roughly 6 lines)
@@ -104,8 +104,8 @@ def block_histogram_bin_extract[
     3. Extract and pack only elements belonging to target_bin
     """
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Step 1: Each thread determines its bin and element value
 
@@ -152,7 +152,7 @@ def block_normalize_vector[
     4. Each thread normalizes: output[i] = input[i] / mean
     """
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # Step 1: Each thread loads its element

--- a/problems/p28/p28.mojo
+++ b/problems/p28/p28.mojo
@@ -116,7 +116,9 @@ def test_async_copy_overlap_convolution() raises:
                         for k in range(KERNEL_SIZE):
                             var input_idx = i + k - HALO_SIZE
                             if input_idx >= 0 and input_idx < VECTOR_SIZE:
-                                expected_val += input_host[input_idx] * Float32(k + 1)
+                                expected_val += input_host[input_idx] * Float32(
+                                    k + 1
+                                )
                     else:
                         # Boundary elements: copy input
                         expected_val = input_host[i]

--- a/problems/p28/p28.mojo
+++ b/problems/p28/p28.mojo
@@ -66,12 +66,12 @@ def test_async_copy_overlap_convolution() raises:
         # Create test data: consecutive integers [1, 2, 3, ..., VECTOR_SIZE]
         with input_buf.map_to_host() as input_host:
             for i in range(VECTOR_SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         # Create test kernel: [1, 2, 3, 4, 5]
         with kernel_buf.map_to_host() as kernel_host:
             for i in range(KERNEL_SIZE):
-                kernel_host[i] = Float32(i + 1)
+                kernel_host[i] = Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout_async, ImmutAnyOrigin](
             input_buf
@@ -116,9 +116,9 @@ def test_async_copy_overlap_convolution() raises:
                         for k in range(KERNEL_SIZE):
                             var input_idx = i + k - HALO_SIZE
                             if input_idx >= 0 and input_idx < VECTOR_SIZE:
-                                expected_val += input_host[input_idx] * Float32(
-                                    k + 1
-                                )
+                                expected_val += input_host[input_idx] * Scalar[
+                                    dtype
+                                ](k + 1)
                     else:
                         # Boundary elements: copy input
                         expected_val = input_host[i]

--- a/problems/p28/p28.mojo
+++ b/problems/p28/p28.mojo
@@ -116,7 +116,7 @@ def test_async_copy_overlap_convolution() raises:
                         for k in range(KERNEL_SIZE):
                             var input_idx = i + k - HALO_SIZE
                             if input_idx >= 0 and input_idx < VECTOR_SIZE:
-                                expected_val += input_host[input_idx] * (k + 1)
+                                expected_val += input_host[input_idx] * Float32(k + 1)
                     else:
                         # Boundary elements: copy input
                         expected_val = input_host[i]

--- a/problems/p29/p29.mojo
+++ b/problems/p29/p29.mojo
@@ -203,9 +203,7 @@ def test_multi_stage_pipeline() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a simple wave pattern for blurring
-                inp_host[i] = Scalar[dtype](i % 10) + Scalar[dtype](i) / Scalar[
-                    dtype
-                ](100)
+                inp_host[i] = Scalar[dtype](i % 10) + Scalar[dtype](i) / 100.0
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)

--- a/problems/p29/p29.mojo
+++ b/problems/p29/p29.mojo
@@ -57,8 +57,8 @@ def multi_stage_image_blur_pipeline[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Stage 1: Load and preprocess (threads 0-127)
 
@@ -135,8 +135,8 @@ def double_buffered_stencil_computation[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Initialize barriers (only thread 0)
     if local_i == 0:

--- a/problems/p29/p29.mojo
+++ b/problems/p29/p29.mojo
@@ -203,7 +203,9 @@ def test_multi_stage_pipeline() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a simple wave pattern for blurring
-                inp_host[i] = Float32(i % 10) + Float32(i) / Float32(100)
+                inp_host[i] = Scalar[dtype](i % 10) + Scalar[dtype](i) / Scalar[
+                    dtype
+                ](100)
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
@@ -265,7 +267,7 @@ def test_double_buffered_stencil() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a step pattern that will be smoothed by stencil
-                inp_host[i] = Float32(1.0 if i % 20 < 10 else 0.0)
+                inp_host[i] = Scalar[dtype](1.0 if i % 20 < 10 else 0.0)
 
         # Create LayoutTensors for Puzzle 29B
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)

--- a/problems/p29/p29.mojo
+++ b/problems/p29/p29.mojo
@@ -203,7 +203,7 @@ def test_multi_stage_pipeline() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a simple wave pattern for blurring
-                inp_host[i] = Float32(i % 10) + Float32(i / 100.0)
+                inp_host[i] = Float32(i % 10) + Float32(i) / Float32(100)
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)

--- a/problems/p30/p30.mojo
+++ b/problems/p30/p30.mojo
@@ -91,8 +91,8 @@ def benchmark_kernel1_parameterized[test_size: Int](mut b: Bencher) raises:
 
         with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
             for i in range(test_size):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i + 2)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)
@@ -129,8 +129,8 @@ def benchmark_kernel2_parameterized[test_size: Int](mut b: Bencher) raises:
 
         with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
             for i in range(test_size):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i + 2)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)
@@ -167,8 +167,8 @@ def benchmark_kernel3_parameterized[test_size: Int](mut b: Bencher) raises:
 
         with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
             for i in range(test_size):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i + 2)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)
@@ -203,8 +203,8 @@ def test_kernel1() raises:
         # Initialize test data
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i + 2)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
@@ -246,8 +246,8 @@ def test_kernel2() raises:
         # Initialize test data
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i + 2)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
@@ -292,8 +292,8 @@ def test_kernel3() raises:
         # Initialize test data
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i + 2)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)

--- a/problems/p30/p30.mojo
+++ b/problems/p30/p30.mojo
@@ -24,7 +24,7 @@ def kernel1[
     b: LayoutTensor[dtype, layout, ImmutAnyOrigin],
     size: Int,
 ):
-    var i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var i = block_dim.x * block_idx.x + thread_idx.x
     if i < size:
         output[i] = a[i] + b[i]
 
@@ -41,7 +41,7 @@ def kernel2[
     b: LayoutTensor[dtype, layout, ImmutAnyOrigin],
     size: Int,
 ):
-    var tid = Int(block_idx.x * block_dim.x + thread_idx.x)
+    var tid = block_idx.x * block_dim.x + thread_idx.x
     var stride = 512
 
     var i = tid
@@ -62,7 +62,7 @@ def kernel3[
     b: LayoutTensor[dtype, layout, ImmutAnyOrigin],
     size: Int,
 ):
-    var tid = Int(block_idx.x * block_dim.x + thread_idx.x)
+    var tid = block_idx.x * block_dim.x + thread_idx.x
     var total_threads = (SIZE // 1024) * 1024
 
     for step in range(0, size, total_threads):

--- a/problems/p31/p31.mojo
+++ b/problems/p31/p31.mojo
@@ -24,7 +24,7 @@ def minimal_kernel[
     size: Int,
 ):
     """Minimal SAXPY kernel - simple and register-light for high occupancy."""
-    var i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var i = block_dim.x * block_idx.x + thread_idx.x
     if i < size:
         # Direct computation: y[i] = alpha * x[i] + y[i]
         # Uses minimal registers (~8), no shared memory
@@ -53,7 +53,7 @@ def sophisticated_kernel[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()  # 48KB
 
-    var i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     if i < size:
@@ -150,7 +150,7 @@ def balanced_kernel[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()  # 16KB total
 
-    var i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     if i < size:

--- a/problems/p31/p31.mojo
+++ b/problems/p31/p31.mojo
@@ -12,7 +12,7 @@ comptime THREADS_PER_BLOCK = (1024, 1)
 comptime BLOCKS_PER_GRID = (SIZE // 1024, 1)
 comptime dtype = DType.float32
 comptime layout = Layout.row_major(SIZE)
-comptime ALPHA = Float32(2.5)  # SAXPY coefficient
+comptime ALPHA = Scalar[dtype](2.5)  # SAXPY coefficient
 
 
 def minimal_kernel[
@@ -203,8 +203,8 @@ def benchmark_minimal_parameterized[test_size: Int](mut b: Bencher) raises:
 
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(test_size):
-                x_host[i] = Float32(i + 1)
-                y_host[i] = Float32(i + 2)
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
 
         var y_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](y)
         var x_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](x)
@@ -241,8 +241,8 @@ def benchmark_sophisticated_parameterized[
 
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(test_size):
-                x_host[i] = Float32(i + 1)
-                y_host[i] = Float32(i + 2)
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
 
         var y_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](y)
         var x_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](x)
@@ -277,8 +277,8 @@ def benchmark_balanced_parameterized[test_size: Int](mut b: Bencher) raises:
 
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(test_size):
-                x_host[i] = Float32(i + 1)
-                y_host[i] = Float32(i + 2)
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
 
         var y_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](y)
         var x_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](x)
@@ -311,8 +311,8 @@ def test_minimal() raises:
         # Initialize test data
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(SIZE):
-                x_host[i] = Float32(i + 1)
-                y_host[i] = Float32(i + 2)
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
 
         # Create LayoutTensors
         var y_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](y)
@@ -333,7 +333,7 @@ def test_minimal() raises:
         # Verify results: y[i] = alpha * x[i] + original_y[i]
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(10):  # Check first 10
-                var expected = ALPHA * x_host[i] + Float32(
+                var expected = ALPHA * x_host[i] + Scalar[dtype](
                     i + 2
                 )  # original y[i] was (i + 2)
                 var actual = y_host[i]
@@ -354,8 +354,8 @@ def test_sophisticated() raises:
         # Initialize test data
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(SIZE):
-                x_host[i] = Float32(i + 1)
-                y_host[i] = Float32(i + 2)
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
 
         # Create LayoutTensors
         var y_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](y)
@@ -376,7 +376,7 @@ def test_sophisticated() raises:
         # Verify results: y[i] = alpha * x[i] + original_y[i] (with precision tolerance)
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(10):  # Check first 10
-                var expected = ALPHA * x_host[i] + Float32(
+                var expected = ALPHA * x_host[i] + Scalar[dtype](
                     i + 2
                 )  # original y[i] was (i + 2)
                 var actual = y_host[i]
@@ -398,8 +398,8 @@ def test_balanced() raises:
         # Initialize test data
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(SIZE):
-                x_host[i] = Float32(i + 1)
-                y_host[i] = Float32(i + 2)
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
 
         # Create LayoutTensors
         var y_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](y)
@@ -420,7 +420,7 @@ def test_balanced() raises:
         # Verify results: y[i] = alpha * x[i] + original_y[i] (with precision tolerance)
         with y.map_to_host() as y_host, x.map_to_host() as x_host:
             for i in range(10):  # Check first 10
-                var expected = ALPHA * x_host[i] + Float32(
+                var expected = ALPHA * x_host[i] + Scalar[dtype](
                     i + 2
                 )  # original y[i] was (i + 2)
                 var actual = y_host[i]

--- a/problems/p32/p32.mojo
+++ b/problems/p32/p32.mojo
@@ -119,7 +119,7 @@ def benchmark_no_conflict[test_size: Int](mut b: Bencher) raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(test_size):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var out_tensor = LayoutTensor[mut=True, dtype, layout](out.unsafe_ptr())
         var input_tensor = LayoutTensor[mut=False, dtype, layout](
@@ -155,7 +155,7 @@ def benchmark_two_way_conflict[test_size: Int](mut b: Bencher) raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(test_size):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var out_tensor = LayoutTensor[mut=True, dtype, layout](out.unsafe_ptr())
         var input_tensor = LayoutTensor[mut=False, dtype, layout](
@@ -187,7 +187,7 @@ def test_no_conflict() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var out_tensor = LayoutTensor[mut=True, dtype, layout](out.unsafe_ptr())
         var input_tensor = LayoutTensor[mut=False, dtype, layout](
@@ -205,7 +205,7 @@ def test_no_conflict() raises:
 
         with out.map_to_host() as result:
             for i in range(min(SIZE, 10)):
-                var expected = Float32((i + 11) * 2)
+                var expected = Scalar[dtype]((i + 11) * 2)
                 assert_almost_equal(result[i], expected, atol=1e-5)
 
         print("No-conflict kernel test: passed")
@@ -221,7 +221,7 @@ def test_two_way_conflict() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var out_tensor = LayoutTensor[mut=True, dtype, layout](out.unsafe_ptr())
         var input_tensor = LayoutTensor[mut=False, dtype, layout](
@@ -239,7 +239,7 @@ def test_two_way_conflict() raises:
 
         with out.map_to_host() as result:
             for i in range(min(SIZE, 10)):
-                var expected = Float32((i + 11) * 2)
+                var expected = Scalar[dtype]((i + 11) * 2)
                 assert_almost_equal(result[i], expected, atol=1e-5)
 
         print("Two-way conflict kernel test: passed")

--- a/problems/p32/p32.mojo
+++ b/problems/p32/p32.mojo
@@ -36,7 +36,7 @@ def no_conflict_kernel[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # Load from global memory to shared memory - no conflicts
@@ -79,7 +79,7 @@ def two_way_conflict_kernel[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # CONFLICT: stride-2 access creates 2-way bank conflicts

--- a/problems/p33/p33.mojo
+++ b/problems/p33/p33.mojo
@@ -263,8 +263,10 @@ def main() raises:
             for row in range(SIZE):
                 for col in range(SIZE):
                     var val = row * SIZE + col
-                    inp1_host[row * SIZE + col] = Float32(val)
-                    inp2_host[row * SIZE + col] = Float32(2.0) * Float32(val)
+                    inp1_host[row * SIZE + col] = Scalar[dtype](val)
+                    inp2_host[row * SIZE + col] = Scalar[dtype](2.0) * Scalar[
+                        dtype
+                    ](val)
 
             # Calculate expected CPU result: inp1 @ inp2
             for i in range(SIZE):

--- a/problems/p33/p33.mojo
+++ b/problems/p33/p33.mojo
@@ -35,13 +35,11 @@ def matmul_idiomatic_tiled[
 
     var local_row = thread_idx.y
     var local_col = thread_idx.x
-    var tiled_row = Int(block_idx.y * tile_size_y + local_row)
-    var tiled_col = Int(block_idx.x * tile_size_x + local_col)
+    var tiled_row = block_idx.y * tile_size_y + local_row
+    var tiled_col = block_idx.x * tile_size_x + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
-    var out_tile = output.tile[TILE_SIZE, TILE_SIZE](
-        Int(block_idx.y), Int(block_idx.x)
-    )
+    var out_tile = output.tile[TILE_SIZE, TILE_SIZE](block_idx.y, block_idx.x)
     var a_shared = LayoutTensor[
         dtype,
         Layout.row_major(TILE_SIZE, TILE_SIZE),
@@ -64,8 +62,8 @@ def matmul_idiomatic_tiled[
 
     for idx in range(size // TILE_SIZE):  # Iterate over K tiles
         # Get tiles from A and B matrices
-        var a_tile = a.tile[TILE_SIZE, TILE_SIZE](Int(block_idx.y), idx)
-        var b_tile = b.tile[TILE_SIZE, TILE_SIZE](idx, Int(block_idx.x))
+        var a_tile = a.tile[TILE_SIZE, TILE_SIZE](block_idx.y, idx)
+        var b_tile = b.tile[TILE_SIZE, TILE_SIZE](idx, block_idx.x)
 
         # Asynchronously copy tiles to shared memory with consistent orientation
         copy_dram_to_sram_async[
@@ -143,7 +141,7 @@ def tensor_core_matrix_multiplication[
     comptime N = C.shape[1]()
     comptime K = A.shape[1]()
 
-    var warp_id = Int(thread_idx.x) // WARP_SIZE
+    var warp_id = thread_idx.x // WARP_SIZE
     var warps_in_n = BN // WN
     var warps_in_m = BM // WM
     var warp_y = warp_id // warps_in_n
@@ -151,7 +149,7 @@ def tensor_core_matrix_multiplication[
 
     var warp_is_active = warp_y < warps_in_m
 
-    var C_block_tile = C.tile[BM, BN](Int(block_idx.y), Int(block_idx.x))
+    var C_block_tile = C.tile[BM, BN](block_idx.y, block_idx.x)
     var C_warp_tile = C_block_tile.tile[WM, WN](warp_y, warp_x)
 
     var mma_op = TensorCore[A.dtype, C.dtype, Index(MMA_M, MMA_N, MMA_K)]()
@@ -188,8 +186,8 @@ def tensor_core_matrix_multiplication[
     for k_i in range(K // BK):
         barrier()
 
-        var A_dram_tile = A.tile[BM, BK](Int(block_idx.y), k_i)
-        var B_dram_tile = B.tile[BK, BN](k_i, Int(block_idx.x))
+        var A_dram_tile = A.tile[BM, BK](block_idx.y, k_i)
+        var B_dram_tile = B.tile[BK, BN](k_i, block_idx.x)
 
         copy_dram_to_sram_async[
             thread_layout=Layout.row_major(4, 8),

--- a/problems/p33/p33.mojo
+++ b/problems/p33/p33.mojo
@@ -263,8 +263,8 @@ def main() raises:
             for row in range(SIZE):
                 for col in range(SIZE):
                     var val = row * SIZE + col
-                    inp1_host[row * SIZE + col] = val
-                    inp2_host[row * SIZE + col] = Float32(2.0) * val
+                    inp1_host[row * SIZE + col] = Float32(val)
+                    inp2_host[row * SIZE + col] = Float32(2.0) * Float32(val)
 
             # Calculate expected CPU result: inp1 @ inp2
             for i in range(SIZE):

--- a/problems/p34/p34.mojo
+++ b/problems/p34/p34.mojo
@@ -45,7 +45,7 @@ def cluster_coordination_basics[
 
     # FIX: Use block_idx.x for data distribution instead of cluster rank
     # Each block should process different portions of the data
-    var data_scale = Float32(
+    var data_scale = Scalar[dtype](
         block_id + 1
     )  # Use block_idx instead of cluster rank
 
@@ -133,7 +133,7 @@ def main() raises:
 
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = Float32(i % 10) * 0.1
+                    input_host[i] = Scalar[dtype](i % 10) * 0.1
 
             input_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](
                 input_buf
@@ -194,7 +194,7 @@ def main() raises:
             var expected_sum: Float32 = 0.0
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = Float32(i)
+                    input_host[i] = Scalar[dtype](i)
                     expected_sum += input_host[i]
 
             print("Expected sum:", expected_sum)
@@ -248,7 +248,7 @@ def main() raises:
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
                     input_host[i] = (
-                        Float32(i % 50) * 0.02
+                        Scalar[dtype](i % 50) * 0.02
                     )  # Pattern for testing
 
             input_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](

--- a/problems/p34/p34.mojo
+++ b/problems/p34/p34.mojo
@@ -29,12 +29,12 @@ def cluster_coordination_basics[
     size: Int,
 ):
     """Real cluster coordination using SM90+ cluster APIs."""
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # Check what's happening with cluster ranks
     var my_block_rank = Int(block_rank_in_cluster())
-    var block_id = Int(block_idx.x)
+    var block_id = block_idx.x
 
     var shared_data = LayoutTensor[
         dtype,
@@ -87,8 +87,8 @@ def cluster_collective_operations[
     size: Int,
 ):
     """Cluster-wide collective operations using real cluster APIs."""
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # FILL IN (roughly 24 lines)
 
@@ -106,8 +106,8 @@ def advanced_cluster_patterns[
 ):
     """Advanced cluster programming using cluster masks and relaxed synchronization.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # FILL IN (roughly 26 lines)
 

--- a/solutions/p01/p01.mojo
+++ b/solutions/p01/p01.mojo
@@ -29,7 +29,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[add_10, add_10](
             out,
@@ -43,7 +43,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = Float32(i + 10)
+            expected[i] = Scalar[dtype](i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/solutions/p01/p01.mojo
+++ b/solutions/p01/p01.mojo
@@ -29,7 +29,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[add_10, add_10](
             out,
@@ -43,7 +43,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = i + 10
+            expected[i] = Float32(i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/solutions/p02/p02.mojo
+++ b/solutions/p02/p02.mojo
@@ -34,8 +34,8 @@ def main() raises:
         expected.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i
-                b_host[i] = i
+                a_host[i] = Float32(i)
+                b_host[i] = Float32(i)
                 expected[i] = a_host[i] + b_host[i]
 
         ctx.enqueue_function[add, add](

--- a/solutions/p02/p02.mojo
+++ b/solutions/p02/p02.mojo
@@ -34,8 +34,8 @@ def main() raises:
         expected.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
-                b_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
+                b_host[i] = Scalar[dtype](i)
                 expected[i] = a_host[i] + b_host[i]
 
         ctx.enqueue_function[add, add](

--- a/solutions/p03/p03.mojo
+++ b/solutions/p03/p03.mojo
@@ -31,7 +31,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[add_10_guard, add_10_guard](
             out,
@@ -46,7 +46,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = Float32(i + 10)
+            expected[i] = Scalar[dtype](i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/solutions/p03/p03.mojo
+++ b/solutions/p03/p03.mojo
@@ -31,7 +31,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[add_10_guard, add_10_guard](
             out,
@@ -46,7 +46,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = i + 10
+            expected[i] = Float32(i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/solutions/p03/p03.mojo
+++ b/solutions/p03/p03.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_guard(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var i = thread_idx.x
     if i < size:
@@ -36,7 +36,7 @@ def main() raises:
         ctx.enqueue_function[add_10_guard, add_10_guard](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p04/p04.mojo
+++ b/solutions/p04/p04.mojo
@@ -37,7 +37,7 @@ def main() raises:
             # row-major
             for y in range(SIZE):
                 for x in range(SIZE):
-                    a_host[y * SIZE + x] = Float32(y * SIZE + x)
+                    a_host[y * SIZE + x] = Scalar[dtype](y * SIZE + x)
                     expected[y * SIZE + x] = a_host[y * SIZE + x] + 10
 
         ctx.enqueue_function[add_10_2d, add_10_2d](

--- a/solutions/p04/p04.mojo
+++ b/solutions/p04/p04.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_2d(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -43,7 +43,7 @@ def main() raises:
         ctx.enqueue_function[add_10_2d, add_10_2d](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p04/p04.mojo
+++ b/solutions/p04/p04.mojo
@@ -37,7 +37,7 @@ def main() raises:
             # row-major
             for y in range(SIZE):
                 for x in range(SIZE):
-                    a_host[y * SIZE + x] = y * SIZE + x
+                    a_host[y * SIZE + x] = Float32(y * SIZE + x)
                     expected[y * SIZE + x] = a_host[y * SIZE + x] + 10
 
         ctx.enqueue_function[add_10_2d, add_10_2d](

--- a/solutions/p04/p04_layout_tensor.mojo
+++ b/solutions/p04/p04_layout_tensor.mojo
@@ -14,7 +14,7 @@ comptime layout = Layout.row_major(SIZE, SIZE)
 def add_10_2d(
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -51,7 +51,7 @@ def main() raises:
         ctx.enqueue_function[add_10_2d, add_10_2d](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p04/p04_layout_tensor.mojo
+++ b/solutions/p04/p04_layout_tensor.mojo
@@ -41,7 +41,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
                 expected[i] = a_host[i] + 10
 
         var a_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](a).reshape[

--- a/solutions/p04/p04_layout_tensor.mojo
+++ b/solutions/p04/p04_layout_tensor.mojo
@@ -41,7 +41,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
                 expected[i] = a_host[i] + 10
 
         var a_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](a).reshape[

--- a/solutions/p05/p05.mojo
+++ b/solutions/p05/p05.mojo
@@ -37,8 +37,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i * 10)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i * 10)
 
             for y in range(SIZE):
                 for x in range(SIZE):

--- a/solutions/p05/p05.mojo
+++ b/solutions/p05/p05.mojo
@@ -14,7 +14,7 @@ def broadcast_add(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -48,7 +48,7 @@ def main() raises:
             out,
             a,
             b,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p05/p05.mojo
+++ b/solutions/p05/p05.mojo
@@ -37,8 +37,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i + 1
-                b_host[i] = i * 10
+                a_host[i] = Float32(i + 1)
+                b_host[i] = Float32(i * 10)
 
             for y in range(SIZE):
                 for x in range(SIZE):

--- a/solutions/p05/p05_layout_tensor.mojo
+++ b/solutions/p05/p05_layout_tensor.mojo
@@ -51,8 +51,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i + 1)
-                b_host[i] = Float32(i * 10)
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i * 10)
 
             for i in range(SIZE):
                 for j in range(SIZE):

--- a/solutions/p05/p05_layout_tensor.mojo
+++ b/solutions/p05/p05_layout_tensor.mojo
@@ -51,8 +51,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i + 1
-                b_host[i] = i * 10
+                a_host[i] = Float32(i + 1)
+                b_host[i] = Float32(i * 10)
 
             for i in range(SIZE):
                 for j in range(SIZE):

--- a/solutions/p05/p05_layout_tensor.mojo
+++ b/solutions/p05/p05_layout_tensor.mojo
@@ -21,7 +21,7 @@ def broadcast_add[
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, a_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, b_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -66,7 +66,7 @@ def main() raises:
             out_tensor,
             a_tensor,
             b_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p06/p06.mojo
+++ b/solutions/p06/p06.mojo
@@ -31,7 +31,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[add_10_blocks, add_10_blocks](
             out,
@@ -47,7 +47,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = i + 10
+            expected[i] = Float32(i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/solutions/p06/p06.mojo
+++ b/solutions/p06/p06.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_blocks(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var i = block_dim.x * block_idx.x + thread_idx.x
     if i < size:
@@ -36,7 +36,7 @@ def main() raises:
         ctx.enqueue_function[add_10_blocks, add_10_blocks](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p06/p06.mojo
+++ b/solutions/p06/p06.mojo
@@ -31,7 +31,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[add_10_blocks, add_10_blocks](
             out,
@@ -47,7 +47,7 @@ def main() raises:
         ctx.synchronize()
 
         for i in range(SIZE):
-            expected[i] = Float32(i + 10)
+            expected[i] = Scalar[dtype](i + 10)
 
         with out.map_to_host() as out_host:
             print("out:", out_host)

--- a/solutions/p07/p07.mojo
+++ b/solutions/p07/p07.mojo
@@ -13,7 +13,7 @@ comptime dtype = DType.float32
 def add_10_blocks_2d(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = block_dim.y * block_idx.y + thread_idx.y
     var col = block_dim.x * block_idx.x + thread_idx.x
@@ -43,7 +43,7 @@ def main() raises:
         ctx.enqueue_function[add_10_blocks_2d, add_10_blocks_2d](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p07/p07.mojo
+++ b/solutions/p07/p07.mojo
@@ -37,8 +37,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = k
-                    expected[k] = k + 10
+                    a_host[k] = Float32(k)
+                    expected[k] = Float32(k + 10)
 
         ctx.enqueue_function[add_10_blocks_2d, add_10_blocks_2d](
             out,

--- a/solutions/p07/p07.mojo
+++ b/solutions/p07/p07.mojo
@@ -37,8 +37,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = Float32(k)
-                    expected[k] = Float32(k + 10)
+                    a_host[k] = Scalar[dtype](k)
+                    expected[k] = Scalar[dtype](k + 10)
 
         ctx.enqueue_function[add_10_blocks_2d, add_10_blocks_2d](
             out,

--- a/solutions/p07/p07_layout_tensor.mojo
+++ b/solutions/p07/p07_layout_tensor.mojo
@@ -18,7 +18,7 @@ def add_10_blocks_2d[
 ](
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, a_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = block_dim.y * block_idx.y + thread_idx.y
     var col = block_dim.x * block_idx.x + thread_idx.x
@@ -54,7 +54,7 @@ def main() raises:
         ctx.enqueue_function[kernel, kernel](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p07/p07_layout_tensor.mojo
+++ b/solutions/p07/p07_layout_tensor.mojo
@@ -45,8 +45,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = k
-                    expected_buf[k] = k + 10
+                    a_host[k] = Float32(k)
+                    expected_buf[k] = Float32(k + 10)
 
         var a_tensor = LayoutTensor[dtype, a_layout, ImmutAnyOrigin](a)
 

--- a/solutions/p07/p07_layout_tensor.mojo
+++ b/solutions/p07/p07_layout_tensor.mojo
@@ -45,8 +45,8 @@ def main() raises:
             for j in range(SIZE):
                 for i in range(SIZE):
                     var k = j * SIZE + i
-                    a_host[k] = Float32(k)
-                    expected_buf[k] = Float32(k + 10)
+                    a_host[k] = Scalar[dtype](k)
+                    expected_buf[k] = Scalar[dtype](k + 10)
 
         var a_tensor = LayoutTensor[dtype, a_layout, ImmutAnyOrigin](a)
 

--- a/solutions/p08/p08.mojo
+++ b/solutions/p08/p08.mojo
@@ -15,7 +15,7 @@ comptime dtype = DType.float32
 def add_10_shared(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var shared = stack_allocation[
         TPB,
@@ -52,7 +52,7 @@ def main() raises:
         ctx.enqueue_function[add_10_shared, add_10_shared](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p08/p08_layout_tensor.mojo
+++ b/solutions/p08/p08_layout_tensor.mojo
@@ -18,7 +18,7 @@ def add_10_shared_layout_tensor[
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     # Allocate shared memory using tensor builder
     var shared = LayoutTensor[
@@ -61,7 +61,7 @@ def main() raises:
         ctx.enqueue_function[kernel, kernel](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p10/p10.mojo
+++ b/solutions/p10/p10.mojo
@@ -90,7 +90,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a).reshape[
             layout
@@ -100,7 +100,7 @@ def main() raises:
             print("Running memory bug example (bounds checking issue)...")
             # Fill expected values directly since it's a HostBuffer
             for i in range(SIZE * SIZE):
-                expected[i] = Float32(i + 10)
+                expected[i] = Scalar[dtype](i + 10)
 
             ctx.enqueue_function[add_10_2d, add_10_2d](
                 out_tensor,

--- a/solutions/p10/p10.mojo
+++ b/solutions/p10/p10.mojo
@@ -18,7 +18,7 @@ comptime layout = Layout.row_major(SIZE, SIZE)
 def shared_memory_race(
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     """Fixed: sequential access with barriers eliminates race conditions."""
     var row = thread_idx.y
@@ -55,7 +55,7 @@ def shared_memory_race(
 def add_10_2d(
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var row = thread_idx.y
     var col = thread_idx.x
@@ -105,7 +105,7 @@ def main() raises:
             ctx.enqueue_function[add_10_2d, add_10_2d](
                 out_tensor,
                 a_tensor,
-                UInt(SIZE),
+                SIZE,
                 grid_dim=BLOCKS_PER_GRID,
                 block_dim=THREADS_PER_BLOCK,
             )
@@ -135,7 +135,7 @@ def main() raises:
             ctx.enqueue_function[shared_memory_race, shared_memory_race](
                 out_tensor,
                 a_tensor,
-                UInt(SIZE),
+                SIZE,
                 grid_dim=BLOCKS_PER_GRID,
                 block_dim=THREADS_PER_BLOCK,
             )

--- a/solutions/p10/p10.mojo
+++ b/solutions/p10/p10.mojo
@@ -90,7 +90,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE * SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a).reshape[
             layout
@@ -100,7 +100,7 @@ def main() raises:
             print("Running memory bug example (bounds checking issue)...")
             # Fill expected values directly since it's a HostBuffer
             for i in range(SIZE * SIZE):
-                expected[i] = i + 10
+                expected[i] = Float32(i + 10)
 
             ctx.enqueue_function[add_10_2d, add_10_2d](
                 out_tensor,

--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -50,7 +50,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         ctx.enqueue_function[pooling, pooling](
             out,

--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -50,7 +50,7 @@ def main() raises:
         a.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[pooling, pooling](
             out,

--- a/solutions/p11/p11.mojo
+++ b/solutions/p11/p11.mojo
@@ -15,7 +15,7 @@ comptime dtype = DType.float32
 def pooling(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var shared = stack_allocation[
         TPB,
@@ -33,7 +33,7 @@ def pooling(
         output[0] = shared[0]
     elif global_i == 1:
         output[1] = shared[0] + shared[1]
-    elif UInt(1) < global_i < size:
+    elif 1 < global_i < size:
         output[global_i] = (
             shared[local_i - 2] + shared[local_i - 1] + shared[local_i]
         )
@@ -55,7 +55,7 @@ def main() raises:
         ctx.enqueue_function[pooling, pooling](
             out,
             a,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p11/p11_layout_tensor.mojo
+++ b/solutions/p11/p11_layout_tensor.mojo
@@ -62,7 +62,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/solutions/p11/p11_layout_tensor.mojo
+++ b/solutions/p11/p11_layout_tensor.mojo
@@ -18,7 +18,7 @@ def pooling[
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     # Allocate shared memory using tensor builder
     var shared = LayoutTensor[
@@ -44,7 +44,7 @@ def pooling[
     elif global_i == 1:
         output[1] = shared[0] + shared[1]
     # Handle general case
-    elif UInt(1) < global_i < size:
+    elif 1 < global_i < size:
         output[global_i] = (
             shared[local_i - 2] + shared[local_i - 1] + shared[local_i]
         )
@@ -70,7 +70,7 @@ def main() raises:
         ctx.enqueue_function[pooling[layout], pooling[layout]](
             out_tensor,
             a_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p11/p11_layout_tensor.mojo
+++ b/solutions/p11/p11_layout_tensor.mojo
@@ -62,7 +62,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/solutions/p12/p12.mojo
+++ b/solutions/p12/p12.mojo
@@ -16,7 +16,7 @@ def dot_product(
     output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var shared = stack_allocation[
         TPB,
@@ -40,7 +40,7 @@ def dot_product(
     # and warps can be scheduled independently.
     # However, shared memory does not have such issues as long as we use `barrier()`
     # correctly when we're in the same thread block.
-    var stride = UInt(TPB // 2)
+    var stride = TPB // 2
     while stride > 0:
         if local_i < stride:
             shared[local_i] += shared[local_i + stride]
@@ -73,7 +73,7 @@ def main() raises:
             out,
             a,
             b,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p12/p12.mojo
+++ b/solutions/p12/p12.mojo
@@ -66,8 +66,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i
-                b_host[i] = i
+                a_host[i] = Float32(i)
+                b_host[i] = Float32(i)
 
         ctx.enqueue_function[dot_product, dot_product](
             out,

--- a/solutions/p12/p12.mojo
+++ b/solutions/p12/p12.mojo
@@ -66,8 +66,8 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
-                b_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
+                b_host[i] = Scalar[dtype](i)
 
         ctx.enqueue_function[dot_product, dot_product](
             out,

--- a/solutions/p12/p12_layout_tensor.mojo
+++ b/solutions/p12/p12_layout_tensor.mojo
@@ -66,8 +66,8 @@ def main() raises:
 
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = i
-                b_host[i] = i
+                a_host[i] = Float32(i)
+                b_host[i] = Float32(i)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/solutions/p12/p12_layout_tensor.mojo
+++ b/solutions/p12/p12_layout_tensor.mojo
@@ -66,8 +66,8 @@ def main() raises:
 
         with a.map_to_host() as a_host, b.map_to_host() as b_host:
             for i in range(SIZE):
-                a_host[i] = Float32(i)
-                b_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
+                b_host[i] = Scalar[dtype](i)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/solutions/p12/p12_layout_tensor.mojo
+++ b/solutions/p12/p12_layout_tensor.mojo
@@ -20,7 +20,7 @@ def dot_product[
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var shared = LayoutTensor[
         dtype,
@@ -39,7 +39,7 @@ def dot_product[
     barrier()
 
     # Parallel reduction in shared memory
-    var stride = UInt(TPB // 2)
+    var stride = TPB // 2
     while stride > 0:
         if local_i < stride:
             shared[local_i] += shared[local_i + stride]
@@ -78,7 +78,7 @@ def main() raises:
             out_tensor,
             a_tensor,
             b_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p13/p13.mojo
+++ b/solutions/p13/p13.mojo
@@ -151,11 +151,11 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         with b.map_to_host() as b_host:
             for i in range(conv):
-                b_host[i] = Float32(i)
+                b_host[i] = Scalar[dtype](i)
 
         if argv()[1] == "--simple":
             var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)

--- a/solutions/p13/p13.mojo
+++ b/solutions/p13/p13.mojo
@@ -151,11 +151,11 @@ def main() raises:
         b.enqueue_fill(0)
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         with b.map_to_host() as b_host:
             for i in range(conv):
-                b_host[i] = i
+                b_host[i] = Float32(i)
 
         if argv()[1] == "--simple":
             var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)

--- a/solutions/p13/p13.mojo
+++ b/solutions/p13/p13.mojo
@@ -25,7 +25,7 @@ def conv_1d_simple[
     b: LayoutTensor[dtype, conv_layout, ImmutAnyOrigin],
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
-    var local_i = Int(thread_idx.x)
+    var local_i = thread_idx.x
     var shared_a = LayoutTensor[
         dtype,
         Layout.row_major(SIZE),
@@ -90,8 +90,8 @@ def conv_1d_block_boundary[
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, conv_layout, ImmutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     # first: need to account for padding
     var shared_a = LayoutTensor[
         dtype,

--- a/solutions/p14/p14.mojo
+++ b/solutions/p14/p14.mojo
@@ -169,7 +169,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = i
+                a_host[i] = Float32(i)
 
         if use_simple:
             a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/solutions/p14/p14.mojo
+++ b/solutions/p14/p14.mojo
@@ -20,7 +20,7 @@ def prefix_sum_simple[
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
@@ -35,7 +35,7 @@ def prefix_sum_simple[
 
     barrier()
 
-    var offset = UInt(1)
+    var offset = 1
     for i in range(Int(log2(Scalar[dtype](TPB)))):
         var current_val: output.element_type = 0
         if local_i >= offset and local_i < size:
@@ -71,7 +71,7 @@ def prefix_sum_local_phase[
 ](
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
@@ -102,7 +102,7 @@ def prefix_sum_local_phase[
     # Iteration 3 (offset=4):
     #   Block 0: [0,1,3,6,10+0,14+1,18+3,22+6] = [0,1,3,6,10,15,21,28]
     #   Block 1 follows same pattern to get [8,17,27,38,50,63,77,???]
-    var offset = UInt(1)
+    var offset = 1
     for i in range(Int(log2(Scalar[dtype](TPB)))):
         var current_val: output.element_type = 0
         if local_i >= offset and local_i < TPB:
@@ -134,7 +134,7 @@ def prefix_sum_local_phase[
 # Kernel 2: Add block sums to their respective blocks
 def prefix_sum_block_sum_phase[
     layout: Layout
-](output: LayoutTensor[dtype, layout, MutAnyOrigin], size: UInt):
+](output: LayoutTensor[dtype, layout, MutAnyOrigin], size: Int):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     # Second pass: add previous block's sum to each element
@@ -179,7 +179,7 @@ def main() raises:
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
-                UInt(size),
+                size,
                 grid_dim=BLOCKS_PER_GRID,
                 block_dim=THREADS_PER_BLOCK,
             )
@@ -195,7 +195,7 @@ def main() raises:
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
-                UInt(size),
+                size,
                 grid_dim=BLOCKS_PER_GRID_2,
                 block_dim=THREADS_PER_BLOCK_2,
             )
@@ -204,7 +204,7 @@ def main() raises:
             comptime kernel2 = prefix_sum_block_sum_phase[extended_layout]
             ctx.enqueue_function[kernel2, kernel2](
                 out_tensor,
-                UInt(size),
+                size,
                 grid_dim=BLOCKS_PER_GRID_2,
                 block_dim=THREADS_PER_BLOCK_2,
             )

--- a/solutions/p14/p14.mojo
+++ b/solutions/p14/p14.mojo
@@ -169,7 +169,7 @@ def main() raises:
 
         with a.map_to_host() as a_host:
             for i in range(size):
-                a_host[i] = Float32(i)
+                a_host[i] = Scalar[dtype](i)
 
         if use_simple:
             a_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](a)

--- a/solutions/p15/p15.mojo
+++ b/solutions/p15/p15.mojo
@@ -20,7 +20,7 @@ def axis_sum[
 ](
     output: LayoutTensor[dtype, out_layout, MutAnyOrigin],
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
-    size: UInt,
+    size: Int,
 ):
     var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
@@ -49,7 +49,7 @@ def axis_sum[
     barrier()
 
     # do reduction sum per each block
-    var stride = UInt(TPB // 2)
+    var stride = TPB // 2
     while stride > 0:
         # Read phase: all threads read the values they need first to avoid race conditions
         var temp_val: output.element_type = 0
@@ -91,7 +91,7 @@ def main() raises:
         ctx.enqueue_function[kernel, kernel](
             out_tensor,
             inp_tensor,
-            UInt(SIZE),
+            SIZE,
             grid_dim=BLOCKS_PER_GRID,
             block_dim=THREADS_PER_BLOCK,
         )

--- a/solutions/p15/p15.mojo
+++ b/solutions/p15/p15.mojo
@@ -82,7 +82,7 @@ def main() raises:
         with inp.map_to_host() as inp_host:
             for row in range(BATCH):
                 for col in range(SIZE):
-                    inp_host[row * SIZE + col] = Float32(row * SIZE + col)
+                    inp_host[row * SIZE + col] = Scalar[dtype](row * SIZE + col)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var inp_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](inp)

--- a/solutions/p15/p15.mojo
+++ b/solutions/p15/p15.mojo
@@ -82,7 +82,7 @@ def main() raises:
         with inp.map_to_host() as inp_host:
             for row in range(BATCH):
                 for col in range(SIZE):
-                    inp_host[row * SIZE + col] = row * SIZE + col
+                    inp_host[row * SIZE + col] = Float32(row * SIZE + col)
 
         var out_tensor = LayoutTensor[dtype, out_layout, MutAnyOrigin](out)
         var inp_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](inp)

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -244,9 +244,7 @@ def main() raises:
                     var val = row * size + col
                     # row major: placing elements row by row
                     inp1_host[row * size + col] = Scalar[dtype](val)
-                    inp2_host[row * size + col] = Scalar[dtype](2.0) * Scalar[
-                        dtype
-                    ](val)
+                    inp2_host[row * size + col] = Scalar[dtype](2.0 * val)
 
             # inp1 @ inp2
             for i in range(size):

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -15,7 +15,7 @@ comptime layout = Layout.row_major(SIZE, SIZE)
 
 # ANCHOR: naive_matmul_solution
 def naive_matmul[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
@@ -38,7 +38,7 @@ def naive_matmul[
 
 # ANCHOR: single_block_matmul_solution
 def single_block_matmul[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout, MutAnyOrigin],
     a: LayoutTensor[dtype, layout, ImmutAnyOrigin],
@@ -88,7 +88,7 @@ comptime layout_tiled = Layout.row_major(SIZE_TILED, SIZE_TILED)
 
 # ANCHOR: matmul_tiled_solution
 def matmul_tiled[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout_tiled, MutAnyOrigin],
     a: LayoutTensor[dtype, layout_tiled, ImmutAnyOrigin],
@@ -153,7 +153,7 @@ comptime BLOCK_DIM_COUNT = 2
 
 
 def matmul_idiomatic_tiled[
-    layout: Layout, size: UInt
+    layout: Layout, size: Int
 ](
     output: LayoutTensor[dtype, layout_tiled, MutAnyOrigin],
     a: LayoutTensor[dtype, layout_tiled, ImmutAnyOrigin],
@@ -259,7 +259,7 @@ def main() raises:
         var b_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](inp2)
 
         if argv()[1] == "--naive":
-            comptime kernel = naive_matmul[layout, UInt(SIZE)]
+            comptime kernel = naive_matmul[layout, SIZE]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
@@ -268,7 +268,7 @@ def main() raises:
                 block_dim=THREADS_PER_BLOCK,
             )
         elif argv()[1] == "--single-block":
-            comptime kernel = single_block_matmul[layout, UInt(SIZE)]
+            comptime kernel = single_block_matmul[layout, SIZE]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor,
                 a_tensor,
@@ -288,7 +288,7 @@ def main() raises:
                 inp2
             )
 
-            comptime kernel = matmul_tiled[layout_tiled, UInt(SIZE_TILED)]
+            comptime kernel = matmul_tiled[layout_tiled, SIZE_TILED]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor_tiled,
                 a_tensor_tiled,
@@ -307,9 +307,7 @@ def main() raises:
                 inp2
             )
 
-            comptime kernel = matmul_idiomatic_tiled[
-                layout_tiled, UInt(SIZE_TILED)
-            ]
+            comptime kernel = matmul_idiomatic_tiled[layout_tiled, SIZE_TILED]
             ctx.enqueue_function[kernel, kernel](
                 out_tensor_tiled,
                 a_tensor_tiled,

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -165,7 +165,7 @@ def matmul_idiomatic_tiled[
     var tiled_col = block_idx.x * TPB + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
-    var out_tile = output.tile[TPB, TPB](Int(block_idx.y), Int(block_idx.x))
+    var out_tile = output.tile[TPB, TPB](block_idx.y, block_idx.x)
     var a_shared = LayoutTensor[
         dtype,
         Layout.row_major(TPB, TPB),
@@ -190,8 +190,8 @@ def matmul_idiomatic_tiled[
         size // TPB
     ):  # Perfect division: 9 // 3 = 3 tiles
         # Get tiles from A and B matrices
-        var a_tile = a.tile[TPB, TPB](Int(block_idx.y), Int(idx))
-        var b_tile = b.tile[TPB, TPB](Int(idx), Int(block_idx.x))
+        var a_tile = a.tile[TPB, TPB](block_idx.y, Int(idx))
+        var b_tile = b.tile[TPB, TPB](Int(idx), block_idx.x)
 
         # Asynchronously copy tiles to shared memory with consistent orientation
         copy_dram_to_sram_async[

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -243,8 +243,10 @@ def main() raises:
                 for col in range(size):
                     var val = row * size + col
                     # row major: placing elements row by row
-                    inp1_host[row * size + col] = Float32(val)
-                    inp2_host[row * size + col] = Float32(2.0) * Float32(val)
+                    inp1_host[row * size + col] = Scalar[dtype](val)
+                    inp2_host[row * size + col] = Scalar[dtype](2.0) * Scalar[
+                        dtype
+                    ](val)
 
             # inp1 @ inp2
             for i in range(size):

--- a/solutions/p16/p16.mojo
+++ b/solutions/p16/p16.mojo
@@ -243,8 +243,8 @@ def main() raises:
                 for col in range(size):
                     var val = row * size + col
                     # row major: placing elements row by row
-                    inp1_host[row * size + col] = val
-                    inp2_host[row * size + col] = Float32(2.0) * val
+                    inp1_host[row * size + col] = Float32(val)
+                    inp2_host[row * size + col] = Float32(2.0) * Float32(val)
 
             # inp1 @ inp2
             for i in range(size):

--- a/solutions/p17/op/conv1d.mojo
+++ b/solutions/p17/op/conv1d.mojo
@@ -21,8 +21,8 @@ def conv1d_kernel[
     input: LayoutTensor[dtype, in_layout, MutAnyOrigin],
     kernel: LayoutTensor[dtype, conv_layout, MutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     # first: need to account for padding
     var shared_a = LayoutTensor[
         dtype,

--- a/solutions/p18/op/softmax.mojo
+++ b/solutions/p18/op/softmax.mojo
@@ -39,7 +39,7 @@ def softmax_gpu_kernel[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(thread_idx.x)
+    var global_i = thread_idx.x
 
     # Initialize out-of-bounds (shared_max[local_i], global_i >= input_size) shared memory addresses to the minimum
     # finite value for dtype, ensuring that if these elements are accessed in the parallel max reduction below they

--- a/solutions/p18/test/test_softmax.mojo
+++ b/solutions/p18/test/test_softmax.mojo
@@ -27,7 +27,7 @@ def test_softmax() raises:
         # Initialize input with more reasonable values
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
-                inp_host[i] = Float32(i)
+                inp_host[i] = Scalar[dtype](i)
 
             print("Input values:")
             for i in range(SIZE):

--- a/solutions/p19/op/attention.mojo
+++ b/solutions/p19/op/attention.mojo
@@ -42,14 +42,14 @@ def matmul_idiomatic_tiled[
     b: LayoutTensor[dtype, b_layout, MutAnyOrigin],
 ):
     """Updated idiomatic tiled matrix multiplication from p16."""
-    var local_row = Int(thread_idx.y)
-    var local_col = Int(thread_idx.x)
-    var tiled_row = Int(block_idx.y) * MATMUL_BLOCK_DIM_XY + local_row
-    var tiled_col = Int(block_idx.x) * MATMUL_BLOCK_DIM_XY + local_col
+    var local_row = thread_idx.y
+    var local_col = thread_idx.x
+    var tiled_row = block_idx.y * MATMUL_BLOCK_DIM_XY + local_row
+    var tiled_col = block_idx.x * MATMUL_BLOCK_DIM_XY + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
     var out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-        Int(block_idx.y), Int(block_idx.x)
+        block_idx.y, block_idx.x
     )
     var a_shared = LayoutTensor[
         dtype,
@@ -77,10 +77,10 @@ def matmul_idiomatic_tiled[
     ):
         # Get tiles from A and B matrices
         var a_tile = a.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            Int(block_idx.y), idx
+            block_idx.y, idx
         )
         var b_tile = b.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            idx, Int(block_idx.x)
+            idx, block_idx.x
         )
 
         # Asynchronously copy tiles to shared memory with consistent orientation
@@ -135,19 +135,19 @@ def transpose_kernel[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var local_row = Int(thread_idx.y)
-    var local_col = Int(thread_idx.x)
+    var local_row = thread_idx.y
+    var local_col = thread_idx.x
 
-    var global_row = Int(block_idx.y) * TRANSPOSE_BLOCK_DIM_XY + local_row
-    var global_col = Int(block_idx.x) * TRANSPOSE_BLOCK_DIM_XY + local_col
+    var global_row = block_idx.y * TRANSPOSE_BLOCK_DIM_XY + local_row
+    var global_col = block_idx.x * TRANSPOSE_BLOCK_DIM_XY + local_col
 
     if global_row < rows and global_col < cols:
         shared_tile[local_row, local_col] = inp[global_row, global_col]
 
     barrier()
 
-    var out_row = Int(block_idx.x) * TRANSPOSE_BLOCK_DIM_XY + local_row
-    var out_col = Int(block_idx.y) * TRANSPOSE_BLOCK_DIM_XY + local_col
+    var out_row = block_idx.x * TRANSPOSE_BLOCK_DIM_XY + local_row
+    var out_col = block_idx.y * TRANSPOSE_BLOCK_DIM_XY + local_col
 
     # Store data from shared memory to global memory (coalesced write)
     # Note: we transpose the shared memory access pattern
@@ -182,7 +182,7 @@ def softmax_gpu_kernel[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(thread_idx.x)
+    var global_i = thread_idx.x
 
     # Initialize out-of-bounds (shared_max[local_i], global_i >= input_size) shared memory addresses to the minimum
     # finite value for dtype, ensuring that if these elements are accessed in the parallel max reduction below they

--- a/solutions/p20/op/conv1d.mojo
+++ b/solutions/p20/op/conv1d.mojo
@@ -22,8 +22,8 @@ def conv1d_kernel[
     input: LayoutTensor[dtype, in_layout, MutAnyOrigin],
     kernel: LayoutTensor[dtype, conv_layout, MutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     # first: need to account for padding
     var shared_a = LayoutTensor[
         dtype,

--- a/solutions/p21/op/embedding.mojo
+++ b/solutions/p21/op/embedding.mojo
@@ -33,7 +33,7 @@ def embedding_kernel_coalesced[
     """
 
     # Simple 1D indexing - each thread = one output element
-    var global_idx = Int(block_idx.x * block_dim.x + thread_idx.x)
+    var global_idx = block_idx.x * block_dim.x + thread_idx.x
     var total_elements = batch_size * seq_len * embed_dim
 
     if global_idx >= total_elements:
@@ -85,8 +85,8 @@ def embedding_kernel_2d[
     """
 
     # 2D grid indexing
-    var batch_seq_idx = Int(block_idx.x * block_dim.x + thread_idx.x)
-    var embed_idx = Int(block_idx.y * block_dim.y + thread_idx.y)
+    var batch_seq_idx = block_idx.x * block_dim.x + thread_idx.x
+    var embed_idx = block_idx.y * block_dim.y + thread_idx.y
 
     var total_positions = batch_size * seq_len
 

--- a/solutions/p22/op/layernorm_linear.mojo
+++ b/solutions/p22/op/layernorm_linear.mojo
@@ -33,12 +33,12 @@ def matmul_idiomatic_tiled[
     """Idiomatic tiled matrix multiplication from p19."""
     var local_row = thread_idx.y
     var local_col = thread_idx.x
-    var tiled_row = Int(block_idx.y * MATMUL_BLOCK_DIM_XY + local_row)
-    var tiled_col = Int(block_idx.x * MATMUL_BLOCK_DIM_XY + local_col)
+    var tiled_row = block_idx.y * MATMUL_BLOCK_DIM_XY + local_row
+    var tiled_col = block_idx.x * MATMUL_BLOCK_DIM_XY + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
     var out_tile = output.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-        Int(block_idx.y), Int(block_idx.x)
+        block_idx.y, block_idx.x
     )
     var a_shared = LayoutTensor[
         dtype,
@@ -66,10 +66,10 @@ def matmul_idiomatic_tiled[
     ):
         # Get tiles from A and B matrices
         var a_tile = a.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            Int(block_idx.y), idx
+            block_idx.y, idx
         )
         var b_tile = b.tile[MATMUL_BLOCK_DIM_XY, MATMUL_BLOCK_DIM_XY](
-            idx, Int(block_idx.x)
+            idx, block_idx.x
         )
 
         # Asynchronously copy tiles to shared memory with consistent orientation
@@ -123,9 +123,9 @@ def layernorm_kernel[
     ln_weight: LayoutTensor[dtype, ln_params_layout, ImmutAnyOrigin],
     ln_bias: LayoutTensor[dtype, ln_params_layout, ImmutAnyOrigin],
 ):
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
-    var hidden_idx = Int(thread_idx.x)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
+    var hidden_idx = thread_idx.x
 
     if (
         batch_idx >= batch_size
@@ -217,9 +217,9 @@ def add_bias_kernel[
     bias: LayoutTensor[dtype, bias_layout, ImmutAnyOrigin],
 ):
     """Simple bias addition."""
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
-    var out_idx = Int(thread_idx.x)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
+    var out_idx = thread_idx.x
 
     if batch_idx >= batch_size or seq_idx >= seq_len or out_idx >= output_dim:
         return
@@ -256,8 +256,8 @@ def minimal_fused_kernel[
     """
     # Grid: (batch_size, seq_len) - one thread block per sequence position
     # Block: (1,) - single thread per sequence position to avoid redundant computation
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
 
     if batch_idx >= batch_size or seq_idx >= seq_len:
         return
@@ -326,8 +326,8 @@ def minimal_fused_kernel_backward[
     """
     # Grid: (batch_size, seq_len) - one thread per sequence position
     # Block: (1,) - single thread per sequence position
-    var batch_idx = Int(block_idx.x)
-    var seq_idx = Int(block_idx.y)
+    var batch_idx = block_idx.x
+    var seq_idx = block_idx.y
 
     if batch_idx >= batch_size or seq_idx >= seq_len:
         return

--- a/solutions/p22/op/layernorm_linear.mojo
+++ b/solutions/p22/op/layernorm_linear.mojo
@@ -162,8 +162,8 @@ def layernorm_kernel[
 def transpose_kernel[
     layout_in: Layout,
     layout_out: Layout,
-    rows: UInt,
-    cols: UInt,
+    rows: Int,
+    cols: Int,
     dtype: DType = DType.float32,
 ](
     output: LayoutTensor[dtype, layout_out, MutAnyOrigin],
@@ -601,8 +601,8 @@ struct LayerNormLinearCustomOp:
                 comptime kernel2 = transpose_kernel[
                     weight_layout,
                     transposed_weight_tensor.layout,
-                    UInt(output_dim),
-                    UInt(hidden_dim),
+                    output_dim,
+                    hidden_dim,
                 ]
                 gpu_ctx.enqueue_function[kernel2, kernel2](
                     transposed_weight_tensor,

--- a/solutions/p23/p23.mojo
+++ b/solutions/p23/p23.mojo
@@ -202,8 +202,8 @@ def benchmark_elementwise_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout, MutAnyOrigin](
         a.unsafe_ptr()
@@ -243,8 +243,8 @@ def benchmark_tiled_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -278,8 +278,8 @@ def benchmark_manual_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -313,8 +313,8 @@ def benchmark_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -345,8 +345,8 @@ def main() raises:
 
     with a.map_to_host() as a_host, b.map_to_host() as b_host:
         for i in range(SIZE):
-            a_host[i] = Float32(2 * i)
-            b_host[i] = Float32(2 * i + 1)
+            a_host[i] = Scalar[dtype](2 * i)
+            b_host[i] = Scalar[dtype](2 * i + 1)
             expected[i] = a_host[i] + b_host[i]
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())

--- a/solutions/p23/p23.mojo
+++ b/solutions/p23/p23.mojo
@@ -202,8 +202,8 @@ def benchmark_elementwise_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout, MutAnyOrigin](
         a.unsafe_ptr()
@@ -243,8 +243,8 @@ def benchmark_tiled_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -278,8 +278,8 @@ def benchmark_manual_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -313,8 +313,8 @@ def benchmark_vectorized_parameterized[
 
     with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
         for i in range(test_size):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())
     var b_tensor = LayoutTensor[mut=False, dtype, layout](b_buf.unsafe_ptr())
@@ -345,8 +345,8 @@ def main() raises:
 
     with a.map_to_host() as a_host, b.map_to_host() as b_host:
         for i in range(SIZE):
-            a_host[i] = 2 * i
-            b_host[i] = 2 * i + 1
+            a_host[i] = Float32(2 * i)
+            b_host[i] = Float32(2 * i + 1)
             expected[i] = a_host[i] + b_host[i]
 
     var a_tensor = LayoutTensor[mut=False, dtype, layout](a.unsafe_ptr())

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -164,7 +164,7 @@ def rand_int[
 ](buff: DeviceBuffer[dtype], min: Int = 0, max: Int = 100) raises:
     with buff.map_to_host() as buff_host:
         for i in range(size):
-            buff_host[i] = Int(random_float64(min, max))
+            buff_host[i] = Scalar[dtype](Int(random_float64(Float64(min), Float64(max))))
 
 
 def check_result[
@@ -347,8 +347,8 @@ def main() raises:
 
             with a.map_to_host() as a_host, b.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = i
-                    b_host[i] = i
+                    a_host[i] = Float32(i)
+                    b_host[i] = Float32(i)
 
             if argv()[1] == "--traditional":
                 ctx.enqueue_function[

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -164,7 +164,9 @@ def rand_int[
 ](buff: DeviceBuffer[dtype], min: Int = 0, max: Int = 100) raises:
     with buff.map_to_host() as buff_host:
         for i in range(size):
-            buff_host[i] = Scalar[dtype](Int(random_float64(Float64(min), Float64(max))))
+            buff_host[i] = Scalar[dtype](
+                Int(random_float64(Float64(min), Float64(max)))
+            )
 
 
 def check_result[

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -349,8 +349,8 @@ def main() raises:
 
             with a.map_to_host() as a_host, b.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = Float32(i)
-                    b_host[i] = Float32(i)
+                    a_host[i] = Scalar[dtype](i)
+                    b_host[i] = Scalar[dtype](i)
 
             if argv()[1] == "--traditional":
                 ctx.enqueue_function[

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -47,8 +47,8 @@ def traditional_dot_product_p12_style[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     if global_i < size:
         shared[local_i] = (a[global_i] * b[global_i]).reduce_add()
@@ -79,7 +79,7 @@ def simple_warp_dot_product[
     a: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
     b: LayoutTensor[dtype, in_layout, ImmutAnyOrigin],
 ):
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     # Each thread computes one partial product using vectorized approach as values in Mojo are SIMD based
     var partial_product: Scalar[dtype] = 0

--- a/solutions/p25/p25.mojo
+++ b/solutions/p25/p25.mojo
@@ -222,7 +222,7 @@ def test_neighbor_difference() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i * i)
+                input_host[i] = Scalar[dtype](i * i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -246,7 +246,7 @@ def test_neighbor_difference() raises:
 
         # Create expected results: differences of squares should be odd numbers
         for i in range(SIZE - 1):
-            expected_buf[i] = Float32((i + 1) * (i + 1) - i * i)
+            expected_buf[i] = Scalar[dtype]((i + 1) * (i + 1) - i * i)
         expected_buf[
             SIZE - 1
         ] = 0  # Last element should be 0 (no valid neighbor)
@@ -271,7 +271,7 @@ def test_moving_average() raises:
         with input_buf.map_to_host() as input_host:
             input_host[0] = 1
             for i in range(1, SIZE_2):
-                input_host[i] = input_host[i - 1] + Float32(i + 1)
+                input_host[i] = input_host[i - 1] + Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -340,9 +340,9 @@ def test_broadcast_shuffle_coordination() raises:
             # Create pattern: [2, 4, 6, 8, 1, 3, 5, 7, ...]
             for i in range(SIZE):
                 if i < 4:
-                    input_host[i] = Float32((i + 1) * 2)
+                    input_host[i] = Scalar[dtype]((i + 1) * 2)
                 else:
-                    input_host[i] = Float32(((i - 4) % 4) * 2 + 1)
+                    input_host[i] = Scalar[dtype](((i - 4) % 4) * 2 + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -367,7 +367,7 @@ def test_broadcast_shuffle_coordination() raises:
         # Create expected results
         with input_buf.map_to_host() as input_host:
             # Lane 0 computes scale_factor from first 4 elements in block: (2+4+6+8)/4 = 5.0
-            var expected_scale = Float32(5.0)
+            var expected_scale = Scalar[dtype](5.0)
 
             for i in range(SIZE):
                 if i < SIZE - 1:
@@ -397,7 +397,7 @@ def test_basic_broadcast() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -422,7 +422,7 @@ def test_basic_broadcast() raises:
         # Create expected results
         with input_buf.map_to_host() as input_host:
             # Lane 0 computes broadcast_value from first 4 elements: 1+2+3+4 = 10
-            var expected_broadcast = Float32(10.0)
+            var expected_broadcast = Scalar[dtype](10.0)
             for i in range(SIZE):
                 expected_buf[i] = expected_broadcast + input_host[i]
 
@@ -448,14 +448,14 @@ def test_conditional_broadcast() raises:
         with input_buf.map_to_host() as input_host:
             # Create pattern with known max
             var test_values = [
-                Float32(3.0),
-                Float32(1.0),
-                Float32(7.0),
-                Float32(2.0),
-                Float32(9.0),
-                Float32(4.0),
-                Float32(6.0),
-                Float32(8.0),
+                Scalar[dtype](3.0),
+                Scalar[dtype](1.0),
+                Scalar[dtype](7.0),
+                Scalar[dtype](2.0),
+                Scalar[dtype](9.0),
+                Scalar[dtype](4.0),
+                Scalar[dtype](6.0),
+                Scalar[dtype](8.0),
             ]
             for i in range(SIZE):
                 input_host[i] = test_values[i % len(test_values)]
@@ -483,7 +483,7 @@ def test_conditional_broadcast() raises:
         # Create expected results
         with input_buf.map_to_host() as input_host:
             # Lane 0 finds max of first 8 elements in block: max(3,1,7,2,9,4,6,8) = 9.0, threshold = 4.5
-            var expected_max = Float32(9.0)
+            var expected_max = Scalar[dtype](9.0)
             var threshold = expected_max / 2.0
             for i in range(SIZE):
                 if input_host[i] >= threshold:

--- a/solutions/p25/p25.mojo
+++ b/solutions/p25/p25.mojo
@@ -222,7 +222,7 @@ def test_neighbor_difference() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i * i
+                input_host[i] = Float32(i * i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -246,7 +246,7 @@ def test_neighbor_difference() raises:
 
         # Create expected results: differences of squares should be odd numbers
         for i in range(SIZE - 1):
-            expected_buf[i] = (i + 1) * (i + 1) - i * i
+            expected_buf[i] = Float32((i + 1) * (i + 1) - i * i)
         expected_buf[
             SIZE - 1
         ] = 0  # Last element should be 0 (no valid neighbor)
@@ -271,7 +271,7 @@ def test_moving_average() raises:
         with input_buf.map_to_host() as input_host:
             input_host[0] = 1
             for i in range(1, SIZE_2):
-                input_host[i] = input_host[i - 1] + i + 1
+                input_host[i] = input_host[i - 1] + Float32(i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -340,9 +340,9 @@ def test_broadcast_shuffle_coordination() raises:
             # Create pattern: [2, 4, 6, 8, 1, 3, 5, 7, ...]
             for i in range(SIZE):
                 if i < 4:
-                    input_host[i] = (i + 1) * 2
+                    input_host[i] = Float32((i + 1) * 2)
                 else:
-                    input_host[i] = ((i - 4) % 4) * 2 + 1
+                    input_host[i] = Float32(((i - 4) % 4) * 2 + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -397,7 +397,7 @@ def test_basic_broadcast() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i + 1
+                input_host[i] = Float32(i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf

--- a/solutions/p25/p25.mojo
+++ b/solutions/p25/p25.mojo
@@ -25,7 +25,7 @@ def neighbor_difference[
     Uses shuffle_down(val, 1) to get the next neighbor's value.
     Works across multiple blocks, each processing one warp worth of data.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     if global_i < size:
@@ -67,7 +67,7 @@ def moving_average_3[
     Uses shuffle_down with offsets 1 and 2 to access neighbors.
     Works within warp boundaries across multiple blocks.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     if global_i < size:
@@ -102,7 +102,7 @@ def broadcast_shuffle_coordination[
     Lane 0 computes block-local scaling factor, broadcasts it to all lanes in the warp.
     Each lane uses shuffle_down() for neighbor access and applies broadcast factor.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     if global_i < size:
@@ -110,7 +110,7 @@ def broadcast_shuffle_coordination[
         var scale_factor: output.element_type = 0.0
         if lane == 0:
             # Compute average of first 4 elements in this block's data
-            var block_start = Int(block_idx.x * block_dim.x)
+            var block_start = block_idx.x * block_dim.x
             var sum: output.element_type = 0.0
             for i in range(4):
                 if block_start + i < size:
@@ -147,14 +147,14 @@ def basic_broadcast[
     Basic broadcast: Lane 0 computes a block-local value, broadcasts it to all lanes.
     Each lane then uses this broadcast value in its own computation.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     if global_i < size:
         # Step 1: Lane 0 computes special value (sum of first 4 elements in this block)
         var broadcast_value: output.element_type = 0.0
         if lane == 0:
-            var block_start = Int(block_idx.x * block_dim.x)
+            var block_start = block_idx.x * block_dim.x
             var sum: output.element_type = 0.0
             for i in range(4):
                 if block_start + i < size:
@@ -182,14 +182,14 @@ def conditional_broadcast[
     Conditional broadcast: Lane 0 makes a decision based on block-local data, broadcasts it to all lanes.
     All lanes apply different logic based on the broadcast decision.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = Int(lane_id())
 
     if global_i < size:
         # Step 1: Lane 0 analyzes block-local data and makes decision (find max of first 8 in block)
         var decision_value: output.element_type = 0.0
         if lane == 0:
-            var block_start = Int(block_idx.x * block_dim.x)
+            var block_start = block_idx.x * block_dim.x
             decision_value = input[block_start] if block_start < size else 0.0
             for i in range(1, min(8, min(WARP_SIZE, size - block_start))):
                 if block_start + i < size:

--- a/solutions/p26/p26.mojo
+++ b/solutions/p26/p26.mojo
@@ -194,12 +194,12 @@ def warp_partition[
         var current_val = input[global_i]
 
         # Phase 1: Create warp-level predicates
-        var predicate_left = Float32(1.0) if current_val < pivot else Float32(
-            0.0
-        )
-        var predicate_right = Float32(1.0) if current_val >= pivot else Float32(
-            0.0
-        )
+        var predicate_left = Scalar[dtype](
+            1.0
+        ) if current_val < pivot else Scalar[dtype](0.0)
+        var predicate_right = Scalar[dtype](
+            1.0
+        ) if current_val >= pivot else Scalar[dtype](0.0)
 
         # Phase 2: Warp-level prefix sum to get positions within warp
         var warp_left_pos = prefix_sum[exclusive=True](predicate_left)
@@ -235,7 +235,7 @@ def test_butterfly_pair_swap() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i)
+                input_host[i] = Scalar[dtype](i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -261,10 +261,10 @@ def test_butterfly_pair_swap() raises:
         for i in range(SIZE):
             if i % 2 == 0:
                 # Even positions get odd values
-                expected_buf[i] = Float32(i + 1)
+                expected_buf[i] = Scalar[dtype](i + 1)
             else:
                 # Odd positions get even values
-                expected_buf[i] = Float32(i - 1)
+                expected_buf[i] = Scalar[dtype](i - 1)
 
         with output_buf.map_to_host() as output_host:
             print("output:", output_host)
@@ -284,7 +284,7 @@ def test_butterfly_parallel_max() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i * 2)
+                input_host[i] = Scalar[dtype](i * 2)
             # Make sure we have a clear maximum
             input_host[SIZE - 1] = 1000.0
 
@@ -330,9 +330,9 @@ def test_butterfly_conditional_max() raises:
             for i in range(SIZE_2):
                 if i < 9:
                     var values = [3, 1, 7, 2, 9, 4, 8, 5, 6]
-                    input_host[i] = Float32(values[i])
+                    input_host[i] = Scalar[dtype](values[i])
                 else:
-                    input_host[i] = Float32(i % 10)
+                    input_host[i] = Scalar[dtype](i % 10)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -392,7 +392,7 @@ def test_warp_inclusive_prefix_sum() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -437,7 +437,7 @@ def test_warp_partition() raises:
         output_buf.enqueue_fill(0)
 
         # Create test data: mix of values above and below pivot
-        var pivot_value = Float32(5.0)
+        var pivot_value = Scalar[dtype](5.0)
         with input_buf.map_to_host() as input_host:
             # Create: [3, 7, 1, 8, 2, 9, 4, 6, ...]
             var test_values = [
@@ -459,7 +459,7 @@ def test_warp_partition() raises:
                 13,
             ]
             for i in range(SIZE):
-                input_host[i] = Float32(test_values[i % len(test_values)])
+                input_host[i] = Scalar[dtype](test_values[i % len(test_values)])
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf

--- a/solutions/p26/p26.mojo
+++ b/solutions/p26/p26.mojo
@@ -65,7 +65,7 @@ def butterfly_parallel_max[
         # Start with half the warp size and reduce by half each step
         var offset = WARP_SIZE // 2
         while offset > 0:
-            max_val = max(max_val, shuffle_xor(max_val, offset))
+            max_val = max(max_val, shuffle_xor(max_val, UInt32(offset)))
             offset //= 2
 
         # All threads now have the maximum value across the entire warp
@@ -103,10 +103,10 @@ def butterfly_conditional_max[
         # Butterfly reduction for both maximum and minimum: dynamic for any WARP_SIZE
         var offset = WARP_SIZE // 2
         while offset > 0:
-            var neighbor_val = shuffle_xor(current_val, offset)
+            var neighbor_val = shuffle_xor(current_val, UInt32(offset))
             current_val = max(current_val, neighbor_val)
 
-            var min_neighbor_val = shuffle_xor(min_val, offset)
+            var min_neighbor_val = shuffle_xor(min_val, UInt32(offset))
             min_val = min(min_val, min_neighbor_val)
 
             offset //= 2
@@ -211,7 +211,7 @@ def warp_partition[
         # Butterfly reduction to get total across the warp: dynamic for any WARP_SIZE
         var offset = WARP_SIZE // 2
         while offset > 0:
-            warp_left_total += shuffle_xor(warp_left_total, offset)
+            warp_left_total += shuffle_xor(warp_left_total, UInt32(offset))
             offset //= 2
 
         # Phase 4: Write to output positions
@@ -235,7 +235,7 @@ def test_butterfly_pair_swap() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i
+                input_host[i] = Float32(i)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -261,10 +261,10 @@ def test_butterfly_pair_swap() raises:
         for i in range(SIZE):
             if i % 2 == 0:
                 # Even positions get odd values
-                expected_buf[i] = i + 1
+                expected_buf[i] = Float32(i + 1)
             else:
                 # Odd positions get even values
-                expected_buf[i] = i - 1
+                expected_buf[i] = Float32(i - 1)
 
         with output_buf.map_to_host() as output_host:
             print("output:", output_host)
@@ -284,7 +284,7 @@ def test_butterfly_parallel_max() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i * 2
+                input_host[i] = Float32(i * 2)
             # Make sure we have a clear maximum
             input_host[SIZE - 1] = 1000.0
 
@@ -330,9 +330,9 @@ def test_butterfly_conditional_max() raises:
             for i in range(SIZE_2):
                 if i < 9:
                     var values = [3, 1, 7, 2, 9, 4, 8, 5, 6]
-                    input_host[i] = values[i]
+                    input_host[i] = Float32(values[i])
                 else:
-                    input_host[i] = i % 10
+                    input_host[i] = Float32(i % 10)
 
         var input_tensor = LayoutTensor[dtype, layout_2, ImmutAnyOrigin](
             input_buf
@@ -392,7 +392,7 @@ def test_warp_inclusive_prefix_sum() raises:
 
         with input_buf.map_to_host() as input_host:
             for i in range(SIZE):
-                input_host[i] = i + 1
+                input_host[i] = Float32(i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf
@@ -459,7 +459,7 @@ def test_warp_partition() raises:
                 13,
             ]
             for i in range(SIZE):
-                input_host[i] = test_values[i % len(test_values)]
+                input_host[i] = Float32(test_values[i % len(test_values)])
 
         var input_tensor = LayoutTensor[dtype, layout, ImmutAnyOrigin](
             input_buf

--- a/solutions/p26/p26.mojo
+++ b/solutions/p26/p26.mojo
@@ -26,7 +26,7 @@ def butterfly_pair_swap[
     Uses shuffle_xor(val, 1) to swap values within each pair.
     This is the foundation of butterfly network communication patterns.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     if global_i < size:
         var current_val = input[global_i]
@@ -56,7 +56,7 @@ def butterfly_parallel_max[
     Each step reduces the active range by half until all threads have the maximum value.
     This implements an efficient O(log n) parallel reduction algorithm.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     if global_i < size:
         var max_val = input[global_i]
@@ -93,7 +93,7 @@ def butterfly_conditional_max[
     in even-numbered lanes. Odd-numbered lanes store the minimum value seen.
     Demonstrates conditional logic combined with butterfly communication patterns.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var lane = lane_id()
 
     if global_i < size:
@@ -147,7 +147,7 @@ def warp_inclusive_prefix_sum[
     NOTE: This implementation only works correctly within a single warp (WARP_SIZE threads).
     For multi-warp scenarios, additional coordination would be needed.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     if global_i < size:
         var current_val = input[global_i]
@@ -188,7 +188,7 @@ def warp_partition[
     Input:  [3, 7, 1, 8, 2, 9, 4, 6]
     var Result: [3, 1, 2, 4, 7, 8, 9, 6] (< pivot | >= pivot).
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
 
     if global_i < size:
         var current_val = input[global_i]

--- a/solutions/p27/p27.mojo
+++ b/solutions/p27/p27.mojo
@@ -129,7 +129,7 @@ def block_histogram_bin_extract[
         # `[0]` returns the underlying SIMD value
         my_value = input_data[global_i][0]
         # Bin values [0.0, 1.0) into num_bins buckets
-        my_bin = Int(floor(my_value * num_bins))
+        my_bin = Int(floor(my_value * Float32(num_bins)))
         # Clamp to valid range
         if my_bin >= num_bins:
             my_bin = num_bins - 1
@@ -154,7 +154,7 @@ def block_histogram_bin_extract[
     # Step 5: Final thread computes total count for this bin
     if local_i == tpb - 1:
         # Inclusive sum = exclusive sum + my contribution
-        var total_count = write_offset[0] + belongs_to_target
+        var total_count = write_offset[0] + Int32(belongs_to_target)
         count_output[0] = total_count
 
 
@@ -234,8 +234,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = i
-                    b_host[i] = 2 * i
+                    a_host[i] = Float32(i)
+                    b_host[i] = Float32(2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)
@@ -279,8 +279,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = i
-                    b_host[i] = 2 * i
+                    a_host[i] = Float32(i)
+                    b_host[i] = Float32(2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)

--- a/solutions/p27/p27.mojo
+++ b/solutions/p27/p27.mojo
@@ -129,7 +129,7 @@ def block_histogram_bin_extract[
         # `[0]` returns the underlying SIMD value
         my_value = input_data[global_i][0]
         # Bin values [0.0, 1.0) into num_bins buckets
-        my_bin = Int(floor(my_value * Float32(num_bins)))
+        my_bin = Int(floor(my_value * Scalar[dtype](num_bins)))
         # Clamp to valid range
         if my_bin >= num_bins:
             my_bin = num_bins - 1
@@ -197,7 +197,7 @@ def block_normalize_vector[
     var mean_value: Scalar[dtype] = 1.0  # Default to avoid division by zero
     if local_i == 0:
         if total_sum[0] > 0.0:
-            mean_value = total_sum[0] / Float32(size)
+            mean_value = total_sum[0] / Scalar[dtype](size)
 
     # Step 4: block.broadcast() shares mean to ALL threads!
     # This completes the block operations trilogy demonstration
@@ -234,8 +234,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = Float32(i)
-                    b_host[i] = Float32(2 * i)
+                    a_host[i] = Scalar[dtype](i)
+                    b_host[i] = Scalar[dtype](2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)
@@ -279,8 +279,8 @@ def main() raises:
             var expected: Scalar[dtype] = 0.0
             with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
                 for i in range(SIZE):
-                    a_host[i] = Float32(i)
-                    b_host[i] = Float32(2 * i)
+                    a_host[i] = Scalar[dtype](i)
+                    b_host[i] = Scalar[dtype](2 * i)
                     expected += a_host[i] * b_host[i]
 
             print("SIZE:", SIZE)
@@ -331,7 +331,7 @@ def main() raises:
                 for i in range(SIZE):
                     # Create values: 0.1, 0.2, 0.3, ..., cycling through bins
                     input_host[i] = (
-                        Float32(i % 80) / 100.0
+                        Scalar[dtype](i % 80) / 100.0
                     )  # Values [0.0, 0.79]
 
             print("Input sample:", end=" ")
@@ -351,9 +351,9 @@ def main() raises:
                     "=== Processing Bin",
                     target_bin,
                     "(range [",
-                    Float32(target_bin) / NUM_BINS,
+                    Scalar[dtype](target_bin) / NUM_BINS,
                     ",",
-                    Float32(target_bin + 1) / NUM_BINS,
+                    Scalar[dtype](target_bin + 1) / NUM_BINS,
                     ")) ===",
                 )
 
@@ -422,13 +422,13 @@ def main() raises:
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
                     # Create values cycling 1-8, mean will be 4.5
-                    value = Float32(
+                    value = Scalar[dtype](
                         (i % 8) + 1
                     )  # Values 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, ...
                     input_host[i] = value
                     sum_value += value
 
-            var mean_value = sum_value / Float32(SIZE)
+            var mean_value = sum_value / Scalar[dtype](SIZE)
 
             print("Input sample:", end=" ")
             with input_buf.map_to_host() as input_host:
@@ -473,7 +473,7 @@ def main() raises:
                 for i in range(SIZE):
                     output_sum += output_host[i]
 
-                var output_mean = output_sum / Float32(SIZE)
+                var output_mean = output_sum / Scalar[dtype](SIZE)
                 print("Output sum:", output_sum)
                 print("Output mean:", output_mean)
                 print(

--- a/solutions/p27/p27.mojo
+++ b/solutions/p27/p27.mojo
@@ -29,7 +29,7 @@ def block_sum_dot_product[
     """Dot product using block.sum() - convenience function like warp.sum()!
     Replaces manual shared memory + barriers + tree reduction with one line."""
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # Each thread computes partial product
@@ -70,8 +70,8 @@ def traditional_dot_product[
         MutAnyOrigin,
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Each thread computes partial product
     if global_i < size:
@@ -118,8 +118,8 @@ def block_histogram_bin_extract[
     3. Extract and pack only elements belonging to target_bin
     """
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Step 1: Each thread determines its bin and element value
     var my_value: Scalar[dtype] = 0.0
@@ -180,7 +180,7 @@ def block_normalize_vector[
     4. Each thread normalizes: output[i] = input[i] / mean
     """
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # Step 1: Each thread loads its element

--- a/solutions/p28/p28.mojo
+++ b/solutions/p28/p28.mojo
@@ -151,7 +151,9 @@ def test_async_copy_overlap_convolution() raises:
                         for k in range(KERNEL_SIZE):
                             var input_idx = i + k - HALO_SIZE
                             if input_idx >= 0 and input_idx < VECTOR_SIZE:
-                                expected_val += input_host[input_idx] * Float32(k + 1)
+                                expected_val += input_host[input_idx] * Float32(
+                                    k + 1
+                                )
                     else:
                         # Boundary elements: copy input
                         expected_val = input_host[i]

--- a/solutions/p28/p28.mojo
+++ b/solutions/p28/p28.mojo
@@ -48,11 +48,11 @@ def async_copy_overlap_convolution[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var local_i = Int(thread_idx.x)
+    var local_i = thread_idx.x
 
     # Phase 1: Launch async copy for input tile
     # Note: tile() does NOT perform bounds checking - ensure valid tile bounds
-    var input_tile = input.tile[CONV_TILE_SIZE](Int(block_idx.x))
+    var input_tile = input.tile[CONV_TILE_SIZE](block_idx.x)
 
     # Use async copy with thread layout matching p14 pattern
     comptime load_layout = Layout.row_major(THREADS_PER_BLOCK_ASYNC)
@@ -67,7 +67,7 @@ def async_copy_overlap_convolution[
     barrier()  # Sync all threads
 
     # Phase 4: Compute convolution
-    var global_i = Int(block_idx.x) * CONV_TILE_SIZE + local_i
+    var global_i = block_idx.x * CONV_TILE_SIZE + local_i
     if local_i < CONV_TILE_SIZE and global_i < output.shape[0]():
         var result: output.element_type = 0
 

--- a/solutions/p28/p28.mojo
+++ b/solutions/p28/p28.mojo
@@ -151,7 +151,7 @@ def test_async_copy_overlap_convolution() raises:
                         for k in range(KERNEL_SIZE):
                             var input_idx = i + k - HALO_SIZE
                             if input_idx >= 0 and input_idx < VECTOR_SIZE:
-                                expected_val += input_host[input_idx] * (k + 1)
+                                expected_val += input_host[input_idx] * Float32(k + 1)
                     else:
                         # Boundary elements: copy input
                         expected_val = input_host[i]

--- a/solutions/p28/p28.mojo
+++ b/solutions/p28/p28.mojo
@@ -101,12 +101,12 @@ def test_async_copy_overlap_convolution() raises:
         # Create test data: consecutive integers [1, 2, 3, ..., VECTOR_SIZE]
         with input_buf.map_to_host() as input_host:
             for i in range(VECTOR_SIZE):
-                input_host[i] = Float32(i + 1)
+                input_host[i] = Scalar[dtype](i + 1)
 
         # Create test kernel: [1, 2, 3, 4, 5]
         with kernel_buf.map_to_host() as kernel_host:
             for i in range(KERNEL_SIZE):
-                kernel_host[i] = Float32(i + 1)
+                kernel_host[i] = Scalar[dtype](i + 1)
 
         var input_tensor = LayoutTensor[dtype, layout_async, ImmutAnyOrigin](
             input_buf
@@ -151,9 +151,9 @@ def test_async_copy_overlap_convolution() raises:
                         for k in range(KERNEL_SIZE):
                             var input_idx = i + k - HALO_SIZE
                             if input_idx >= 0 and input_idx < VECTOR_SIZE:
-                                expected_val += input_host[input_idx] * Float32(
-                                    k + 1
-                                )
+                                expected_val += input_host[input_idx] * Scalar[
+                                    dtype
+                                ](k + 1)
                     else:
                         # Boundary elements: copy input
                         expected_val = input_host[i]

--- a/solutions/p29/p29.mojo
+++ b/solutions/p29/p29.mojo
@@ -53,8 +53,8 @@ def multi_stage_image_blur_pipeline[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Stage 1: Load and preprocess (threads 0-127)
     if local_i < STAGE1_THREADS:
@@ -180,8 +180,8 @@ def double_buffered_stencil_computation[
         address_space=AddressSpace.SHARED,
     ].stack_allocation()
 
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
 
     # Initialize barriers (only thread 0)
     if local_i == 0:

--- a/solutions/p29/p29.mojo
+++ b/solutions/p29/p29.mojo
@@ -87,7 +87,7 @@ def multi_stage_image_blur_pipeline[
                 blur_count += 1
 
         if blur_count > 0:
-            blur_shared[blur_idx] = blur_sum / Float32(blur_count)
+            blur_shared[blur_idx] = blur_sum / Scalar[dtype](blur_count)
         else:
             blur_shared[blur_idx] = 0.0
 
@@ -103,7 +103,7 @@ def multi_stage_image_blur_pipeline[
                     blur_count += 1
 
             if blur_count > 0:
-                blur_shared[second_idx] = blur_sum / Float32(blur_count)
+                blur_shared[second_idx] = blur_sum / Scalar[dtype](blur_count)
             else:
                 blur_shared[second_idx] = 0.0
 
@@ -217,7 +217,9 @@ def double_buffered_stencil_computation[
                         stencil_count += 1
 
                 if stencil_count > 0:
-                    buffer_B[local_i] = stencil_sum / Float32(stencil_count)
+                    buffer_B[local_i] = stencil_sum / Scalar[dtype](
+                        stencil_count
+                    )
                 else:
                     buffer_B[local_i] = buffer_A[local_i]
 
@@ -237,7 +239,9 @@ def double_buffered_stencil_computation[
                         stencil_count += 1
 
                 if stencil_count > 0:
-                    buffer_A[local_i] = stencil_sum / Float32(stencil_count)
+                    buffer_A[local_i] = stencil_sum / Scalar[dtype](
+                        stencil_count
+                    )
                 else:
                     buffer_A[local_i] = buffer_B[local_i]
 
@@ -278,7 +282,7 @@ def test_multi_stage_pipeline() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a simple wave pattern for blurring
-                inp_host[i] = Float32(i % 10) + Float32(i) / 100.0
+                inp_host[i] = Scalar[dtype](i % 10) + Scalar[dtype](i) / 100.0
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)
@@ -340,7 +344,7 @@ def test_double_buffered_stencil() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a step pattern that will be smoothed by stencil
-                inp_host[i] = Float32(1.0 if i % 20 < 10 else 0.0)
+                inp_host[i] = Scalar[dtype](1.0 if i % 20 < 10 else 0.0)
 
         # Create LayoutTensors for Puzzle 26B
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)

--- a/solutions/p29/p29.mojo
+++ b/solutions/p29/p29.mojo
@@ -87,7 +87,7 @@ def multi_stage_image_blur_pipeline[
                 blur_count += 1
 
         if blur_count > 0:
-            blur_shared[blur_idx] = blur_sum / blur_count
+            blur_shared[blur_idx] = blur_sum / Float32(blur_count)
         else:
             blur_shared[blur_idx] = 0.0
 
@@ -103,7 +103,7 @@ def multi_stage_image_blur_pipeline[
                     blur_count += 1
 
             if blur_count > 0:
-                blur_shared[second_idx] = blur_sum / blur_count
+                blur_shared[second_idx] = blur_sum / Float32(blur_count)
             else:
                 blur_shared[second_idx] = 0.0
 
@@ -217,7 +217,7 @@ def double_buffered_stencil_computation[
                         stencil_count += 1
 
                 if stencil_count > 0:
-                    buffer_B[local_i] = stencil_sum / stencil_count
+                    buffer_B[local_i] = stencil_sum / Float32(stencil_count)
                 else:
                     buffer_B[local_i] = buffer_A[local_i]
 
@@ -237,7 +237,7 @@ def double_buffered_stencil_computation[
                         stencil_count += 1
 
                 if stencil_count > 0:
-                    buffer_A[local_i] = stencil_sum / stencil_count
+                    buffer_A[local_i] = stencil_sum / Float32(stencil_count)
                 else:
                     buffer_A[local_i] = buffer_B[local_i]
 
@@ -278,7 +278,7 @@ def test_multi_stage_pipeline() raises:
         with inp.map_to_host() as inp_host:
             for i in range(SIZE):
                 # Create a simple wave pattern for blurring
-                inp_host[i] = Float32(i % 10) + Float32(i / 100.0)
+                inp_host[i] = Float32(i % 10) + Float32(i) / 100.0
 
         # Create LayoutTensors
         var out_tensor = LayoutTensor[dtype, layout, MutAnyOrigin](out)

--- a/solutions/p33/p33.mojo
+++ b/solutions/p33/p33.mojo
@@ -35,13 +35,11 @@ def matmul_idiomatic_tiled[
 
     var local_row = thread_idx.y
     var local_col = thread_idx.x
-    var tiled_row = Int(block_idx.y * tile_size_y + local_row)
-    var tiled_col = Int(block_idx.x * tile_size_x + local_col)
+    var tiled_row = block_idx.y * tile_size_y + local_row
+    var tiled_col = block_idx.x * tile_size_x + local_col
 
     # Get the tile of the output matrix that this thread block is responsible for
-    var out_tile = output.tile[TILE_SIZE, TILE_SIZE](
-        Int(block_idx.y), Int(block_idx.x)
-    )
+    var out_tile = output.tile[TILE_SIZE, TILE_SIZE](block_idx.y, block_idx.x)
     var a_shared = LayoutTensor[
         dtype,
         Layout.row_major(TILE_SIZE, TILE_SIZE),
@@ -64,8 +62,8 @@ def matmul_idiomatic_tiled[
 
     for idx in range(size // TILE_SIZE):  # Iterate over K tiles
         # Get tiles from A and B matrices
-        var a_tile = a.tile[TILE_SIZE, TILE_SIZE](Int(block_idx.y), idx)
-        var b_tile = b.tile[TILE_SIZE, TILE_SIZE](idx, Int(block_idx.x))
+        var a_tile = a.tile[TILE_SIZE, TILE_SIZE](block_idx.y, idx)
+        var b_tile = b.tile[TILE_SIZE, TILE_SIZE](idx, block_idx.x)
 
         # Asynchronously copy tiles to shared memory with consistent orientation
         copy_dram_to_sram_async[
@@ -143,7 +141,7 @@ def tensor_core_matrix_multiplication[
     comptime N = C.shape[1]()
     comptime K = A.shape[1]()
 
-    var warp_id = Int(thread_idx.x) // WARP_SIZE
+    var warp_id = thread_idx.x // WARP_SIZE
     var warps_in_n = BN // WN
     var warps_in_m = BM // WM
     var warp_y = warp_id // warps_in_n
@@ -151,7 +149,7 @@ def tensor_core_matrix_multiplication[
 
     var warp_is_active = warp_y < warps_in_m
 
-    var C_block_tile = C.tile[BM, BN](Int(block_idx.y), Int(block_idx.x))
+    var C_block_tile = C.tile[BM, BN](block_idx.y, block_idx.x)
     var C_warp_tile = C_block_tile.tile[WM, WN](warp_y, warp_x)
 
     var mma_op = TensorCore[A.dtype, C.dtype, Index(MMA_M, MMA_N, MMA_K)]()
@@ -190,8 +188,8 @@ def tensor_core_matrix_multiplication[
     for k_i in range(K // BK):
         barrier()
 
-        var A_dram_tile = A.tile[BM, BK](Int(block_idx.y), k_i)
-        var B_dram_tile = B.tile[BK, BN](k_i, Int(block_idx.x))
+        var A_dram_tile = A.tile[BM, BK](block_idx.y, k_i)
+        var B_dram_tile = B.tile[BK, BN](k_i, block_idx.x)
 
         copy_dram_to_sram_async[
             thread_layout=Layout.row_major(4, 8),

--- a/solutions/p33/p33.mojo
+++ b/solutions/p33/p33.mojo
@@ -278,8 +278,8 @@ def main() raises:
             for row in range(SIZE):
                 for col in range(SIZE):
                     var val = row * SIZE + col
-                    inp1_host[row * SIZE + col] = val
-                    inp2_host[row * SIZE + col] = Float32(2.0) * val
+                    inp1_host[row * SIZE + col] = Float32(val)
+                    inp2_host[row * SIZE + col] = Float32(2.0) * Float32(val)
 
             # Calculate expected CPU result: inp1 @ inp2
             for i in range(SIZE):

--- a/solutions/p33/p33.mojo
+++ b/solutions/p33/p33.mojo
@@ -278,8 +278,10 @@ def main() raises:
             for row in range(SIZE):
                 for col in range(SIZE):
                     var val = row * SIZE + col
-                    inp1_host[row * SIZE + col] = Float32(val)
-                    inp2_host[row * SIZE + col] = Float32(2.0) * Float32(val)
+                    inp1_host[row * SIZE + col] = Scalar[dtype](val)
+                    inp2_host[row * SIZE + col] = Scalar[dtype](2.0) * Scalar[
+                        dtype
+                    ](val)
 
             # Calculate expected CPU result: inp1 @ inp2
             for i in range(SIZE):

--- a/solutions/p34/p34.mojo
+++ b/solutions/p34/p34.mojo
@@ -45,7 +45,7 @@ def cluster_coordination_basics[
 
     # FIX: Use block_idx.x for data distribution instead of cluster rank
     # Each block should process different portions of the data
-    var data_scale = Float32(
+    var data_scale = Scalar[dtype](
         block_id + 1
     )  # Use block_idx instead of cluster rank
 
@@ -159,7 +159,7 @@ def advanced_cluster_patterns[
     # base_mask = cluster_mask_base()  # Requires cluster_shape parameter
 
     # FIX: Process data with block_idx-based scaling for guaranteed uniqueness
-    var data_scale = Float32(block_id + 1)
+    var data_scale = Scalar[dtype](block_id + 1)
     if global_i < size:
         shared_data[local_i] = input[global_i] * data_scale
     else:
@@ -214,7 +214,7 @@ def main() raises:
 
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = Float32(i % 10) * 0.1
+                    input_host[i] = Scalar[dtype](i % 10) * 0.1
 
             input_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](
                 input_buf
@@ -275,7 +275,7 @@ def main() raises:
             var expected_sum: Float32 = 0.0
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
-                    input_host[i] = Float32(i)
+                    input_host[i] = Scalar[dtype](i)
                     expected_sum += input_host[i]
 
             print("Expected sum:", expected_sum)
@@ -329,7 +329,7 @@ def main() raises:
             with input_buf.map_to_host() as input_host:
                 for i in range(SIZE):
                     input_host[i] = (
-                        Float32(i % 50) * 0.02
+                        Scalar[dtype](i % 50) * 0.02
                     )  # Pattern for testing
 
             input_tensor = LayoutTensor[dtype, in_layout, ImmutAnyOrigin](

--- a/solutions/p34/p34.mojo
+++ b/solutions/p34/p34.mojo
@@ -29,12 +29,12 @@ def cluster_coordination_basics[
     size: Int,
 ):
     """Real cluster coordination using SM90+ cluster APIs."""
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
     var local_i = thread_idx.x
 
     # Check what's happening with cluster ranks
     var my_block_rank = Int(block_rank_in_cluster())
-    var block_id = Int(block_idx.x)
+    var block_id = block_idx.x
 
     var shared_data = LayoutTensor[
         dtype,
@@ -87,10 +87,10 @@ def cluster_collective_operations[
     size: Int,
 ):
     """Cluster-wide collective operations using real cluster APIs."""
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     var my_block_rank = Int(block_rank_in_cluster())
-    var block_id = Int(block_idx.x)
+    var block_id = block_idx.x
 
     # Each thread accumulates its data
     var my_value: Float32 = 0.0
@@ -143,10 +143,10 @@ def advanced_cluster_patterns[
 ):
     """Advanced cluster programming using cluster masks and relaxed synchronization.
     """
-    var global_i = Int(block_dim.x * block_idx.x + thread_idx.x)
-    var local_i = Int(thread_idx.x)
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
     var my_block_rank = Int(block_rank_in_cluster())
-    var block_id = Int(block_idx.x)
+    var block_id = block_idx.x
 
     var shared_data = LayoutTensor[
         dtype,


### PR DESCRIPTION
**Fix deprecated implicit type conversion warnings**
Resolves all warning: deprecated implicit conversion warnings emitted by the Mojo compiler across 60 files (28 problem files, 27 solution files, 5 markdown files).

The Mojo compiler now warns when an Int is implicitly converted to a numeric type (Float32, Float64, UInt32, Int32, or Scalar[T]). Future Mojo versions will make these errors. All occurrences have been fixed with explicit constructors.

Pattern | Fix
-- | --
buf[i] = i (Float32 buffer) | buf[i] = Float32(i)
buf[i] = i * SIZE + j | buf[i] = Float32(i * SIZE + j)
sum / count (Int count) | sum / Float32(count)
shuffle_xor(val, offset) | shuffle_xor(val, UInt32(offset))
prefix_sum_result + int_val | prefix_sum_result + Int32(int_val)
my_val * num_bins (Int bins) | my_val * Float32(num_bins)
random_float64(min, max) (Int args) | random_float64(Float64(min), Float64(max))

