### PR TITLE
fix: sync pyproject.toml max/mojo versions with pixi.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mojo>=0.25.7.0.dev2025100107,<1.0.0",
-    "max==26.1.0.dev2026010820",
+    "mojo>=0.26.3.0.dev2026033105,<1.0.0",
+    "max==26.3.0.dev2026033105",
     "poethepoet>=0.34.0",
     "scipy>=1.15.3",
     "torch==2.7.1",


### PR DESCRIPTION
## Summary

- `pyproject.toml` was pinned to `max==26.1.0.dev2026010820` (January 2026) while `pixi.toml` targets `max==26.3.0.dev2026033105` (March 2026)
- The January build introduced a breaking change where `def` implicitly gained `raises` semantics, causing parse errors (`def main() raises:` became a duplicate, GPU kernels became non-`DevicePassable`)
- The March build resolved this by unifying `def`/`fn` semantics with neither implicitly raising — making the original puzzle code correct again
- Users installing via `uv` were getting the broken January build; this fix brings `pyproject.toml` in sync with `pixi.toml`

## Test plan

- [ ] Run `uv sync` after this change to pull the March build
- [ ] Verify `uv run poe p01` compiles without parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)