### PR TITLE
[mojo-gpu-puzzles] Restore max dependency on stable; fix mojo-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
     hooks:
     -   id: mojo-format
         name: Mojo Format
-        entry: bash -c 'cd oss/mojo-gpu-puzzles && pixi run format'
+        entry: pixi run format
         language: system
         pass_filenames: false

--- a/pixi.lock
+++ b/pixi.lock
@@ -176,6 +176,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/manimpango-0.6.1-py312hc603cd0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mapbox_earcut-1.0.3-py312hf890105_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mdbook-0.4.52-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -461,6 +463,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/manimpango-0.6.1-py312h8a52ef1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mapbox_earcut-1.0.3-py312he84d598_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mdbook-0.4.52-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -716,6 +720,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/manimpango-0.6.1-py312he6928cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mapbox_earcut-1.0.3-py312h98cfe13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mdbook-0.4.52-hcdef695_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -991,6 +997,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/manimpango-0.6.1-py312hc603cd0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mapbox_earcut-1.0.3-py312hf890105_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mdbook-0.4.52-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -1269,6 +1277,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/manimpango-0.6.1-py312h8a52ef1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mapbox_earcut-1.0.3-py312he84d598_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mdbook-0.4.52-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -1524,6 +1534,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/manimpango-0.6.1-py312he6928cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mapbox_earcut-1.0.3-py312h98cfe13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mdbook-0.4.52-hcdef695_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -1879,6 +1891,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/manimpango-0.6.1-py312hc603cd0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mapbox_earcut-1.0.3-py312hf890105_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mdbook-0.4.52-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -2255,6 +2269,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/manimpango-0.6.1-py312h8a52ef1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mapbox_earcut-1.0.3-py312he84d598_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mdbook-0.4.52-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -2537,6 +2553,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/manimpango-0.6.1-py312he6928cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mapbox_earcut-1.0.3-py312h98cfe13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mdbook-0.4.52-hcdef695_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -2892,6 +2910,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/manimpango-0.6.1-py312hc603cd0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mapbox_earcut-1.0.3-py312hf890105_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mdbook-0.4.52-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -3268,6 +3288,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/manimpango-0.6.1-py312h8a52ef1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mapbox_earcut-1.0.3-py312he84d598_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/linux-aarch64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mdbook-0.4.52-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -3550,6 +3572,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/manimpango-0.6.1-py312he6928cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mapbox_earcut-1.0.3-py312h98cfe13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-26.3.0-3.12release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-core-26.3.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mdbook-0.4.52-hcdef695_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -10616,6 +10640,69 @@ packages:
   version: 3.0.3
   sha256: d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
   requires_python: '>=3.9'
+- conda: https://conda.modular.com/max/linux-64/max-26.3.0-3.12release.conda
+  sha256: ddeb695d64c0f1e185e8e240022ea551e99a3d4d178ee140b44c7523cde6b20d
+  md5: 848ab1014a137be99bb922463bc20133
+  depends:
+  - numpy >=1.18
+  - typing-extensions >=4.12.2
+  - rich >=13.0.1
+  - python 3.12.*
+  - python-gil
+  - max-core ==26.3.0
+  license: LicenseRef-Modular-Proprietary
+  size: 6934402
+  timestamp: 1777595942783
+- conda: https://conda.modular.com/max/linux-aarch64/max-26.3.0-3.12release.conda
+  sha256: 38bc0bd7cb5eb5c40aa8bbf8ab3db675482fbf26ebf9b9e0917f5b49544afc5e
+  md5: 731788762be6e2ed574be2538bd13c51
+  depends:
+  - numpy >=1.18
+  - typing-extensions >=4.12.2
+  - rich >=13.0.1
+  - python 3.12.*
+  - python-gil
+  - max-core ==26.3.0
+  license: LicenseRef-Modular-Proprietary
+  size: 6926338
+  timestamp: 1777595948841
+- conda: https://conda.modular.com/max/osx-arm64/max-26.3.0-3.12release.conda
+  sha256: db8f4baf0f334db81031f35800add3d77a778ca24e092c3b36133bbbe2dc3349
+  md5: 58cf58a3645dcc12f62feac4b2f391a4
+  depends:
+  - numpy >=1.18
+  - typing-extensions >=4.12.2
+  - rich >=13.0.1
+  - python 3.12.*
+  - python-gil
+  - max-core ==26.3.0
+  license: LicenseRef-Modular-Proprietary
+  size: 6312294
+  timestamp: 1777596152467
+- conda: https://conda.modular.com/max/linux-64/max-core-26.3.0-release.conda
+  sha256: 30efb6ae89f0ed7f3eb91af6201735cedcc638be80efac8abac67d0aabb14e04
+  md5: b7ac3af146ba727b7d6684917811fbc3
+  depends:
+  - mojo-compiler ==1.0.0b1
+  license: LicenseRef-Modular-Proprietary
+  size: 163369655
+  timestamp: 1777595990238
+- conda: https://conda.modular.com/max/linux-aarch64/max-core-26.3.0-release.conda
+  sha256: e2b6233b4754aaecbe2d4ee2a95a169c48fb2022b3c0dc88fcad086a79ab98c7
+  md5: e744e77975b5d9418eb5df5fdb57a9aa
+  depends:
+  - mojo-compiler ==1.0.0b1
+  license: LicenseRef-Modular-Proprietary
+  size: 108885399
+  timestamp: 1777595974147
+- conda: https://conda.modular.com/max/osx-arm64/max-core-26.3.0-release.conda
+  sha256: fe23e639512e15511a4743099b80496993f44d967e69e371f981369e8db3bda5
+  md5: 74720ff7f72a64720fd3a21cf7bb6e13
+  depends:
+  - mojo-compiler ==1.0.0b1
+  license: LicenseRef-Modular-Proprietary
+  size: 105528554
+  timestamp: 1777596112930
 - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
   noarch: python
   sha256: c7c36d5b223862acffaaacdfc6f672ca198a046a66f4a956ca57933123fb93b2

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,6 +40,7 @@ system-requirements = { macos = "15.0" }
 [dependencies]
 python = "==3.12"
 mojo = "*" # includes `mojo-compiler`, lsp, debugger, formatter etc.
+max = "==26.3.0" # required for the Python `max` module used by puzzles 17-22
 bash = ">=5.2.21,<6"
 manim = ">=0.18.1,<0.19"
 mdbook = ">=0.4.48,<0.5"


### PR DESCRIPTION
## Summary

- Restore the `max` Python package dependency in `pixi.toml` on `stable`. It was dropped in c85c864 as "redundant", but `max` is not a transitive dep of `mojo`, so puzzles 17-22 (which import `max.driver`, `max.engine`, `max.graph`, `max.experimental.torch`) failed with `No module named 'max'`. Pinned to `==26.3.0` to match the build published on `https://conda.modular.com/max`; `pixi.lock` re-solved.
- Fix the `mojo-format` pre-commit hook entry that did `cd oss/mojo-gpu-puzzles && pixi run format`. Pre-commit always runs hooks from the git repo root, which is the puzzles repo itself in any standalone clone — the `cd` failed and broke every commit. Drop it.

Fixes SDLC-3716.

## Test plan

- [x] `pixi install -e default` succeeds; lockfile contains `max-26.3.0` + `max-core-26.3.0` for `linux-64`, `linux-aarch64`, `osx-arm64`.
- [x] `pixi run -e default python -c "import max.driver, max.dtype, max.engine, max.graph, max.experimental.torch"` succeeds.
- [x] `pixi run -e default p17` and `p20` get past the `No module named 'max'` failure (they now hit a separate, pre-existing TileTensor compile error in `problems/p{17,20}/op/conv1d.mojo` that should be addressed in its own PR).
- [x] `git commit` runs the pre-commit hooks cleanly (mojo-format, trailing-whitespace, end-of-file-fixer all pass).

## Follow-ups

- Mirror the hook fix into the monorepo source-of-truth at `oss/mojo-gpu-puzzles/.pre-commit-config.yaml` so the next copybara sync doesn't undo it.
- Separate ticket for the TileTensor `__getitem__` constraint errors surfaced once the import error was resolved.