### PR TITLE
Fix "Subscribe to updates" link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the results.
 
 Start Learning Now 👉 [puzzles.modular.com](https://puzzles.modular.com/)
 
-> 📬 [Subscribe to updates](https://www.modular.com/company/talk-to-us) to get
+> 📬 [Subscribe to updates](https://docs.modular.com/max/get-started/#stay-in-touch) to get
 > notified when new puzzles are released!
 
 ## Why Mojo🔥


### PR DESCRIPTION
Noticed this link 404s:

<img width="1179" height="773" alt="Screenshot 2026-05-13 at 6 17 05 AM" src="https://github.com/user-attachments/assets/9951c44c-736d-4efd-8888-91916a1ab943" />

So pointed to:

<img width="1121" height="715" alt="Screenshot 2026-05-13 at 6 18 31 AM" src="https://github.com/user-attachments/assets/61154c2b-e1b1-4cfc-aa45-3b149d1bc49c" />

I'm not certain is this the right replacement, but pointed here as an alternative. Super happy to make any changes to help out with this one.