### PR TITLE
[Docs] Add Jetson Orin setup notes with driver workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ workflows.
 > sudo apt update && sudo apt install wslu
 > ```
 
+> **Jetson Orin Users**: The nightly Mojo build requires NVIDIA driver >= 580
+> (CUDA >= 13.0), but the Jetson Orin ships driver 540.x (CUDA 12.6) provided
+> by NVIDIA's JetPack SDK. Set `MODULAR_NVPTX_COMPILER_PATH` to your system
+> `ptxas` as a workaround:
+>
+> ```bash
+> export MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda-12.6/bin/ptxas
+> ```
+>
+> To make this permanent, add it to your `~/.bashrc`:
+>
+> ```bash
+> echo 'export MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda-12.6/bin/ptxas' >> ~/.bashrc
+> ```
+
 ```bash
 # Build and serve the book
 pixi run book

--- a/README.md
+++ b/README.md
@@ -141,20 +141,20 @@ workflows.
 > sudo apt update && sudo apt install wslu
 > ```
 
-> **Jetson Orin Users**: The nightly Mojo build requires NVIDIA driver >= 580
-> (CUDA >= 13.0), but the Jetson Orin ships driver 540.x (CUDA 12.6) provided
-> by NVIDIA's JetPack SDK. Set `MODULAR_NVPTX_COMPILER_PATH` to your system
-> `ptxas` as a workaround:
+> **Older NVIDIA driver workaround**: Mojo and MAX require NVIDIA driver ≥
+> 580 (CUDA ≥ 13.0). Systems still on older drivers (for example, the Jetson
+> Orin shipped with JetPack SDK on driver 540.x / CUDA 12.6) can hit a
+> driver-version error at runtime. Point Mojo at the system `ptxas` to work
+> around it:
 >
 > ```bash
-> export MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda-12.6/bin/ptxas
+> export MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda/bin/ptxas
 > ```
 >
-> To make this permanent, add it to your `~/.bashrc`:
->
-> ```bash
-> echo 'export MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda-12.6/bin/ptxas' >> ~/.bashrc
-> ```
+> The exact path can vary — see the
+> [Mojo system requirements](https://mojolang.org/docs/requirements/#nvidia-gpus)
+> for the canonical CUDA toolchain locations on each platform. Add the export
+> to your `~/.bashrc` (or equivalent shell rc) to make it persistent.
 
 ```bash
 # Build and serve the book

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ workflows.
 > ```
 >
 > The exact path can vary — see the
-> [Mojo system requirements](https://mojolang.org/docs/requirements/#nvidia-gpus)
+> [system requirements](https://mojolang.org/docs/requirements/#nvidia-gpus)
 > for the canonical CUDA toolchain locations on each platform. Add the export
 > to your `~/.bashrc` (or equivalent shell rc) to make it persistent.
 


### PR DESCRIPTION
## Hardware

- **Device**: Jetson Orin Nano Developer Kit (aarch64)
- **GPU**: NVIDIA Orin (nvgpu)
- **Driver**: 540.4.0 (CUDA 12.6)
- **OS**: Linux jetson 5.15.148-tegra (JetPack SDK)
- **Mojo**: MAX nightly (>= 26.3.0)

## Motivation

The nightly Mojo build requires NVIDIA driver >= 580 (CUDA >= 13.0), but the Jetson Orin ships with driver 540.x (CUDA 12.6) provided by NVIDIA's JetPack SDK. Without setting `MODULAR_NVPTX_COMPILER_PATH`, Mojo refuses to run with:

> `Your current NVIDIA GPU driver version is not supported. Required: driver version >= 580 (CUDA >= 13.0) Detected: 540.4.0 (CUDA 12.6)`

Setting `MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda-12.6/bin/ptxas` resolves the issue.

## Testing

All puzzles p01–p08 were executed on the Jetson Orin Nano and passed validation:

### System info

```
$ nvidia-smi
NVIDIA-SMI 540.4.0                Driver Version: 540.4.0      CUDA Version: 12.6
0  Orin (nvgpu)

$ uname -a
Linux jetson 5.15.148-tegra #1 SMP PREEMPT aarch64 aarch64 aarch64 GNU/Linux
```

### Puzzle results

| Puzzle | Status | Output |
|--------|--------|--------|
| p01 — add 10 | ✅ Pass | `out: [10.0, 11.0, 12.0, 13.0]` |
| p02 — add vectors | ✅ Pass | `out: [0.0, 2.0, 4.0, 6.0]` |
| p03 — bounds-check | ✅ Pass | `out: [10.0, 11.0, 12.0, 13.0]` |
| p04 — 2D pointer | ✅ Pass | `out: [10.0, 11.0, 12.0, 13.0]` |
| p04 — TileTensor | ✅ Pass | `out: [10.0, 11.0, 12.0, 13.0]` |
| p05 — broadcast | ✅ Pass | `out: [[1,2],[11,12]]` |
| p06 — 1D multi-block | ✅ Pass | `out: [10..18]` |
| p07 — 2D multi-block | ✅ Pass | 5x5 matrix [10..34] |
| p08 — shared memory | ✅ Pass | `out: [11, 11, ...]` |

### Note on NvMapMemAlloc errors

The Jetson Orin logs `NvMapMemAllocInternalTagged: error 12` messages during GPU memory allocation, but these are harmless and do not affect correctness — all puzzles produce expected results.