### PR TITLE
Fix broken actions-gh-pages pin causing deploy failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           pixi run build-book
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@4b09552702d0b65573696410d4707c765da2630b
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453
         if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ on:
       - stable
     paths:
       - "pixi.lock"
+  workflow_dispatch: {}
 
 permissions:
   id-token: write
@@ -53,7 +54,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/stable'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
## Summary

The push-to-stable deploy from #262 failed at the Deploy step:

\`\`\`
Error: File not found: '.../peaceiris/actions-gh-pages/4b09552702d0b65573696410d4707c765da2630b/lib/index.js'
\`\`\`

The pinned SHA \`4b09552702...\` is a plain source commit on peaceiris/actions-gh-pages that never had the built \`lib/index.js\` committed (only release tags carry the built output). Repins to the \`v4.1.0\` release commit (\`84c30a85c199...\`), which does contain it.

## Also added: workflow_dispatch

\`publish.yml\` only triggers on push/pull_request touching \`pixi.lock\`, so there was no way to re-trigger a deploy (e.g. right now, to actually exercise this fix) without churning the lockfile. Added a \`workflow_dispatch\` trigger and extended the Deploy step's \`if:\` condition to also run for manually dispatched runs on \`stable\`, so future on-demand redeploys don't require a fake lockfile change.

## Test plan

- [ ] Merge this PR
- [ ] Manually dispatch "Publish Puzzles" on \`stable\` and confirm the Deploy step succeeds and puzzles.modular.com updates