### PR TITLE
Complete the missing puzzle solutions (p09, p30–p32) + stable-Mojo compat + toolchain-agnostic infra

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -71,4 +71,4 @@ some-attribute = "value"
 
 [preprocessor.youtube]
 # Custom preprocessor for YouTube embeds
-command = "python ../scripts/youtube_preprocessor.py"
+command = "python3 ../scripts/youtube_preprocessor.py"

--- a/book/i18n/ko/book.toml
+++ b/book/i18n/ko/book.toml
@@ -39,7 +39,7 @@ enable = true
 renderers = ["html"]
 
 [preprocessor.youtube]
-command = "python scripts/youtube_preprocessor.py"
+command = "python3 scripts/youtube_preprocessor.py"
 
 [preprocessor.i18n-status]
-command = "python scripts/i18n_status_preprocessor.py"
+command = "python3 scripts/i18n_status_preprocessor.py"

--- a/scripts/gpu_specs.py
+++ b/scripts/gpu_specs.py
@@ -46,6 +46,7 @@ Usage:
 import argparse
 import os
 import platform
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -115,9 +116,11 @@ def detect_platform() -> str:
 
     # Check for AMD GPU availability
     try:
-        # Check if ROCm is available
+        # Check if ROCm is available (rocm-smi may live in /opt/rocm/bin
+        # without being on PATH)
+        rocm_smi = shutil.which("rocm-smi") or "/opt/rocm/bin/rocm-smi"
         result = subprocess.run(
-            ["rocm-smi", "--showproductname"],
+            [rocm_smi, "--showproductname"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -348,9 +351,10 @@ def get_amd_specs(device_index: int = 0) -> GPUSpecs:
                 },
             )
 
-        # Get basic info from rocm-smi
+        # Get basic info from rocm-smi (fall back to /opt/rocm/bin)
+        rocm_smi = shutil.which("rocm-smi") or "/opt/rocm/bin/rocm-smi"
         result = subprocess.run(
-            ["rocm-smi", "--showproductname"],
+            [rocm_smi, "--showproductname"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -362,7 +366,7 @@ def get_amd_specs(device_index: int = 0) -> GPUSpecs:
 
         # Get memory info
         mem_result = subprocess.run(
-            ["rocm-smi", "--showmeminfo", "vram"],
+            [rocm_smi, "--showmeminfo", "vram"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/scripts/setup_rocm_sdk_fixes.sh
+++ b/scripts/setup_rocm_sdk_fixes.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+# Apply TheRock rocm-sdk venv fixes (idempotent).
+#
+# The TheRock 7.14 nightly rocm-sdk wheels have three issues that break the
+# in-process HIP/HSA stack used by torch + max.experimental.torch on RDNA4:
+#   1. librocprofiler-register.so.0 is internally broken (its own
+#      rocprofiler_configure* symbols unresolvable) -> fatal at dlopen,
+#      poisoning HIP init. Replaced with a no-op stub.
+#   2. torch preloads the sdk's versioned libs while MAX dlopens unversioned
+#      names; without libamdhip64.so / libhsa-runtime64.so symlinks the
+#      process ends up mixing sdk-7.14 and system-7.2 libs -> HSA init fails.
+#   3. librocm_sysdeps_numa dlopens "libnuma.so" (dev symlink, absent on
+#      stock Ubuntu) -> GDA/rocSHMEM init noise.
+#
+# Run after `uv sync` recreates/updates the venv. Requires gcc.
+##===----------------------------------------------------------------------===##
+set -euo pipefail
+
+VENV="${1:-.venv}"
+VENV_SITE="$(ls -d ${VENV}/lib/python3.*/site-packages 2>/dev/null | head -1)"; SDK_CORE="${VENV_SITE}/_rocm_sdk_core/lib"
+SDK_LIBS="${VENV_SITE}/_rocm_sdk_libraries/lib"
+
+if [ ! -d "${SDK_CORE}" ]; then
+    echo "rocm-sdk not found in ${SDK_CORE}; nothing to fix."
+    exit 0
+fi
+
+# --- 1. Stub the broken librocprofiler-register -----------------------------
+REG="${SDK_CORE}/librocprofiler-register.so.0"
+if [ -f "${REG}.orig" ] && [ ! -f "${REG}" ]; then
+    echo "restoring original librocprofiler-register (stub removed)"
+    mv "${REG}.orig" "${REG}"
+fi
+if [ -f "${REG}" ] && ! nm -D "${REG}" 2>/dev/null | grep -q " T rocprofiler_configure$"; then
+    TMP="$(mktemp -d)"
+    cat > "${TMP}/stub.c" <<'EOF'
+/* No-op stub for TheRock's broken librocprofiler-register.so.0. */
+typedef struct rocprofiler_library_api_table_t { void* api; } rocprofiler_library_api_table_t;
+int rocprofiler_configure(void) { return 0; }
+int rocprofiler_configure_attach(void) { return 0; }
+int rocprofiler_attach(void) { return 0; }
+int rocprofiler_detach(void) { return 0; }
+int rocprofiler_set_api_table(void) { return 0; }
+int rocprofiler_register_attach(void) { return 0; }
+int rocprofiler_register_detach(void) { return 0; }
+int rocprofiler_register_error_string(void) { return 0; }
+int rocprofiler_register_invoke_all_registrations(void) { return 0; }
+int rocprofiler_register_invoke_nonpropagated_registrations(void) { return 0; }
+int rocprofiler_register_iterate_registration_info(void) { return 0; }
+int rocprofiler_register_library_api_table(const rocprofiler_library_api_table_t* t) { (void)t; return 0; }
+EOF
+    gcc -shared -fPIC -Wl,-soname,librocprofiler-register.so.0 \
+        -o "${TMP}/librocprofiler-register.so.0" "${TMP}/stub.c"
+    mv "${REG}" "${REG}.orig"
+    cp "${TMP}/librocprofiler-register.so.0" "${REG}"
+    rm -rf "${TMP}"
+    echo "stubbed librocprofiler-register.so.0 (original kept as .orig)"
+fi
+
+# --- 2. Unversioned symlinks so torch and MAX load the same libs ------------
+ln -sf libamdhip64.so.7 "${SDK_CORE}/libamdhip64.so"
+ln -sf libhsa-runtime64.so.1 "${SDK_CORE}/libhsa-runtime64.so"
+echo "ensured unversioned libamdhip64.so / libhsa-runtime64.so symlinks"
+
+# --- 3. libnuma.so for librocm_sysdeps_numa ---------------------------------
+if [ ! -e "${SDK_CORE}/libnuma.so" ]; then
+    NUMA="$(ldconfig -p 2>/dev/null | awk '/libnuma\.so\.1/{print $NF; exit}')"
+    if [ -n "${NUMA}" ]; then
+        ln -sf "${NUMA}" "${SDK_CORE}/libnuma.so"
+        echo "linked libnuma.so -> ${NUMA}"
+    fi
+fi
+
+# --- 4. sitecustomize: preload librocprofiler-sdk RTLD_GLOBAL ---------------
+SC="${VENV_SITE}/sitecustomize.py"
+if [ ! -f "${SC}" ]; then
+    cat > "${SC}" <<'EOF'
+import ctypes, glob, os
+_sdk = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_rocm_sdk_core", "lib")
+for _lib in glob.glob(os.path.join(_sdk, "librocprofiler-sdk.so*")):
+    try:
+        ctypes.CDLL(_lib, mode=ctypes.RTLD_GLOBAL)
+    except OSError:
+        pass
+EOF
+    echo "wrote sitecustomize.py"
+fi
+
+echo "ROCm sdk fixes applied."

--- a/solutions/p09/p09.mojo
+++ b/solutions/p09/p09.mojo
@@ -1,0 +1,374 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# Puzzle 09 solution — three debugging cases, all fixed:
+#
+#   Case 1 (add_10):             input buffer was created with size 0 while
+#                                the kernel reads SIZE elements -> out-of-bounds
+#                                read (illegal address). FIX: allocate SIZE.
+#
+#   Case 2 (process_sliding_window): ITER was 2 but the window has 3 positions
+#                                (left, center, right). Thread 0 missed its
+#                                right neighbour -> wrong results, no crash.
+#                                FIX: ITER = 3 (offsets -1, 0, +1, bounds-guarded).
+#
+#   Case 3 (collaborative_filter): barrier() sat inside `if thread_id <
+#                                SIZE-1` (Phase 2), so only 3 of 4 threads
+#                                reached it -> barrier divergence -> deadlock.
+#                                FIX: read the left neighbour's Phase-1 value
+#                                (no race), then barrier() with all threads,
+#                                then the conditional update, then barrier().
+#
+from std.gpu import thread_idx
+from max.gpu.sync import barrier
+from max.gpu.host import DeviceContext
+from layout import TileTensor
+from layout.tile_layout import row_major
+from layout.tile_tensor import stack_allocation
+from std.testing import assert_equal
+from std.sys import argv
+
+comptime SIZE = 4
+comptime MATRIX_SIZE = 3
+comptime BLOCKS_PER_GRID = 1
+comptime THREADS_PER_BLOCK = SIZE
+comptime dtype = DType.float32
+comptime vector_layout = row_major[SIZE]()
+comptime VectorLayout = type_of(vector_layout)
+# FIX (case 2): window has 3 positions (left, center, right)
+comptime ITER = 3
+
+
+# ANCHOR: first_crash
+def add_10(
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
+):
+    var i = thread_idx.x
+    output[unsafe_offset=i] = a[unsafe_offset=i] + 10.0
+
+
+# ANCHOR_END: first_crash
+
+
+# ANCHOR: second_crash
+def process_sliding_window(
+    output: TileTensor[mut=True, dtype, VectorLayout, MutAnyOrigin],
+    a: TileTensor[mut=False, dtype, VectorLayout, ImmutAnyOrigin],
+):
+    var thread_id = thread_idx.x
+
+    # Each thread processes a sliding window of 3 elements
+    var window_sum = Scalar[dtype](0.0)
+
+    # Sum elements in sliding window: [i-1, i, i+1]
+    for offset in range(ITER):
+        var idx = Int(thread_id) + offset - 1
+        if 0 <= idx < SIZE:
+            var value = a[idx]
+            window_sum += value
+
+    output[thread_id] = window_sum
+
+
+# ANCHOR_END: second_crash
+
+
+# ANCHOR: third_crash
+def collaborative_filter(
+    output: TileTensor[mut=True, dtype, VectorLayout, MutAnyOrigin],
+    a: TileTensor[mut=False, dtype, VectorLayout, ImmutAnyOrigin],
+):
+    var thread_id = thread_idx.x
+
+    # Shared memory workspace for collaborative processing
+    var shared_workspace = stack_allocation[
+        dtype=dtype, address_space=AddressSpace.SHARED
+    ](row_major[SIZE - 1]())
+
+    # Phase 1: Initialize shared workspace (all threads participate)
+    if thread_id < SIZE - 1:
+        shared_workspace[thread_id] = a[thread_id]
+    barrier()
+
+    # FIX (case 3): read the left neighbour's Phase-1 value BEFORE any
+    # conditional barrier — reading shared[thread_id - 1] here is race-free
+    # because Phase-1 writes are complete and no thread writes its own slot
+    # until the barrier below.
+    var left_neighbour = Scalar[dtype](0.0)
+    if thread_id > 0:
+        left_neighbour = shared_workspace[thread_id - 1]
+    barrier()
+
+    # Phase 2: Collaborative processing (all threads reached the barrier)
+    if thread_id < SIZE - 1:
+        shared_workspace[thread_id] += left_neighbour * 0.5
+    barrier()
+
+    # Phase 3: Final synchronization and output
+    barrier()
+
+    # Write filtered results back to output
+    if thread_id < SIZE - 1:
+        output[thread_id] = shared_workspace[thread_id]
+    else:
+        output[thread_id] = a[thread_id]
+
+
+# ANCHOR_END: third_crash
+
+
+def main() raises:
+    if len(argv()) != 2:
+        print(
+            "Usage: mojo p09 [--first-case | --second-case | --third-case |"
+            " --all]"
+        )
+        return
+
+    if argv()[1] == "--first-case":
+        print(
+            "First Case: Try to identify what's wrong without looking at the"
+            " code!"
+        )
+        print()
+
+        with DeviceContext() as ctx:
+            # FIX (case 1): input buffer must be SIZE elements, not 0
+            var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            input_buf.enqueue_fill(0)
+            var result_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            result_buf.enqueue_fill(0)
+
+            # Enqueue function
+            ctx.enqueue_function[add_10](
+                result_buf,
+                input_buf,
+                grid_dim=BLOCKS_PER_GRID,
+                block_dim=THREADS_PER_BLOCK,
+            )
+
+            ctx.synchronize()
+
+            with result_buf.map_to_host() as result_host:
+                print("result:", result_host)
+                for i in range(SIZE):
+                    assert_equal(result_host[i], Scalar[dtype](10.0))
+                print("add_10: correct (no out-of-bounds read) ✅")
+
+    elif argv()[1] == "--second-case":
+        print("This program computes sliding window sums for each position...")
+        print()
+
+        with DeviceContext() as ctx:
+            # Create buffers
+            var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            input_buf.enqueue_fill(0)
+            var output_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            output_buf.enqueue_fill(0)
+
+            # Initialize input [0, 1, 2, 3]
+            with input_buf.map_to_host() as input_host:
+                for i in range(SIZE):
+                    input_host[i] = Scalar[dtype](i)
+
+            # Create TileTensors for structured access
+            var input_tensor = TileTensor[mut=False, dtype, VectorLayout](
+                input_buf, vector_layout
+            )
+            var output_tensor = TileTensor(output_buf, vector_layout)
+
+            print("Input array: [0, 1, 2, 3]")
+            print("Computing sliding window sums (window size = 3)...")
+            print(
+                "Each position should sum its neighbors: [left + center +"
+                " right]"
+            )
+
+            ctx.enqueue_function[process_sliding_window](
+                output_tensor,
+                input_tensor,
+                grid_dim=BLOCKS_PER_GRID,
+                block_dim=THREADS_PER_BLOCK,
+            )
+
+            ctx.synchronize()
+
+            with output_buf.map_to_host() as output_host:
+                print("Actual result:", output_host)
+
+                # Expected sliding window results
+                var expected_0 = Scalar[dtype](1.0)
+                var expected_1 = Scalar[dtype](3.0)
+                var expected_2 = Scalar[dtype](6.0)
+                var expected_3 = Scalar[dtype](5.0)
+                print("Expected: [1.0, 3.0, 6.0, 5.0]")
+
+                # Check if results match expected pattern
+                var matches = True
+                if abs(output_host[0] - expected_0) > 0.001:
+                    matches = False
+                if abs(output_host[1] - expected_1) > 0.001:
+                    matches = False
+                if abs(output_host[2] - expected_2) > 0.001:
+                    matches = False
+                if abs(output_host[3] - expected_3) > 0.001:
+                    matches = False
+
+                if matches:
+                    print(
+                        "[PASS] Test PASSED - Sliding window sums are correct"
+                    )
+                else:
+                    print(
+                        "[FAIL] Test FAILED - Sliding window sums are"
+                        " incorrect!"
+                    )
+                    print("Check the window indexing logic...")
+
+    elif argv()[1] == "--third-case":
+        print(
+            "Third Case: Advanced collaborative filtering with shared memory..."
+        )
+        print()
+
+        with DeviceContext() as ctx:
+            # Create input and output buffers
+            var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            input_buf.enqueue_fill(0)
+            var output_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            output_buf.enqueue_fill(0)
+
+            # Initialize input data [1, 2, 3, 4]
+            with input_buf.map_to_host() as input_host:
+                for i in range(SIZE):
+                    input_host[i] = Scalar[dtype](i + 1)
+
+            # Create TileTensors
+            var input_tensor = TileTensor[mut=False, dtype, VectorLayout](
+                input_buf, vector_layout
+            )
+            var output_tensor = TileTensor(output_buf, vector_layout)
+
+            print("Input array: [1, 2, 3, 4]")
+            print("Applying collaborative filter using shared memory...")
+            print("Each thread cooperates with neighbors for smoothing...")
+
+            # FIX (case 3): no longer hangs — barriers are reached by all
+            # threads
+            ctx.enqueue_function[collaborative_filter](
+                output_tensor,
+                input_tensor,
+                grid_dim=BLOCKS_PER_GRID,
+                block_dim=THREADS_PER_BLOCK,
+            )
+
+            print("Waiting for GPU computation to complete...")
+            ctx.synchronize()
+
+            with output_buf.map_to_host() as output_host:
+                print("Result:", output_host)
+                # Expected: y[i] = a[i] + 0.5*a[i-1] for i<3, y[3] = a[3]
+                # = [1, 2.5, 4.0, 4.0] (thread 2 reads thread 1's PHASE-1
+                # value 2, so 3 + 1.0 = 4.0)
+                assert_equal(output_host[0], Scalar[dtype](1.0))
+                assert_equal(output_host[1], Scalar[dtype](2.5))
+                assert_equal(output_host[2], Scalar[dtype](4.0))
+                assert_equal(output_host[3], Scalar[dtype](4.0))
+                print(
+                    "[SUCCESS] Collaborative filtering completed without"
+                    " deadlock ✅"
+                )
+
+    elif argv()[1] == "--all":
+        print("Puzzle 09 — all three cases:")
+        # Reuse the three case bodies by invoking the fixed kernels directly.
+        # Case 1: add_10 with a properly sized buffer
+        with DeviceContext() as ctx:
+            var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            input_buf.enqueue_fill(0)
+            var result_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            result_buf.enqueue_fill(0)
+            ctx.enqueue_function[add_10](
+                result_buf,
+                input_buf,
+                grid_dim=BLOCKS_PER_GRID,
+                block_dim=THREADS_PER_BLOCK,
+            )
+            ctx.synchronize()
+            with result_buf.map_to_host() as result_host:
+                for i in range(SIZE):
+                    assert_equal(result_host[i], Scalar[dtype](10.0))
+            print("  case 1 (OOB read):            fixed ✅")
+
+        # Case 2: sliding window sums
+        with DeviceContext() as ctx:
+            var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            input_buf.enqueue_fill(0)
+            var output_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            output_buf.enqueue_fill(0)
+            with input_buf.map_to_host() as input_host:
+                for i in range(SIZE):
+                    input_host[i] = Scalar[dtype](i)
+            var input_tensor = TileTensor[mut=False, dtype, VectorLayout](
+                input_buf, vector_layout
+            )
+            var output_tensor = TileTensor(output_buf, vector_layout)
+            ctx.enqueue_function[process_sliding_window](
+                output_tensor,
+                input_tensor,
+                grid_dim=BLOCKS_PER_GRID,
+                block_dim=THREADS_PER_BLOCK,
+            )
+            ctx.synchronize()
+            with output_buf.map_to_host() as output_host:
+                assert_equal(output_host[0], Scalar[dtype](1.0))
+                assert_equal(output_host[1], Scalar[dtype](3.0))
+                assert_equal(output_host[2], Scalar[dtype](6.0))
+                assert_equal(output_host[3], Scalar[dtype](5.0))
+            print("  case 2 (window logic bug):    fixed ✅")
+
+        # Case 3: collaborative filter (no deadlock)
+        with DeviceContext() as ctx:
+            var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            input_buf.enqueue_fill(0)
+            var output_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+            output_buf.enqueue_fill(0)
+            with input_buf.map_to_host() as input_host:
+                for i in range(SIZE):
+                    input_host[i] = Scalar[dtype](i + 1)
+            var input_tensor = TileTensor[mut=False, dtype, VectorLayout](
+                input_buf, vector_layout
+            )
+            var output_tensor = TileTensor(output_buf, vector_layout)
+            ctx.enqueue_function[collaborative_filter](
+                output_tensor,
+                input_tensor,
+                grid_dim=BLOCKS_PER_GRID,
+                block_dim=THREADS_PER_BLOCK,
+            )
+            ctx.synchronize()
+            with output_buf.map_to_host() as output_host:
+                # y[i] = a[i] + 0.5*a[i-1], y[3] = a[3]
+                assert_equal(output_host[0], Scalar[dtype](1.0))
+                assert_equal(output_host[1], Scalar[dtype](2.5))
+                assert_equal(output_host[2], Scalar[dtype](4.0))
+                assert_equal(output_host[3], Scalar[dtype](4.0))
+            print("  case 3 (barrier deadlock):    fixed ✅")
+
+        print("Puzzle 09 complete ✅")
+
+    else:
+        print(
+            "Unsupported option. Choose between [--first-case, --second-case,"
+            " --third-case, --all]"
+        )

--- a/solutions/p23/p23.mojo
+++ b/solutions/p23/p23.mojo
@@ -45,7 +45,7 @@ def elementwise_add[
     b: TileTensor[mut=False, dtype, LayoutT, MutAnyOrigin],
     ctx: DeviceContext,
 ) raises:
-    @__parameter
+    @parameter
     @always_inline
     def add[
         simd_width: Int, alignment: Int = align_of[dtype]()
@@ -86,7 +86,7 @@ def tiled_elementwise_add[
     b: TileTensor[mut=False, dtype, LayoutT, MutAnyOrigin],
     ctx: DeviceContext,
 ) raises:
-    @__parameter
+    @parameter
     @always_inline
     def process_tiles[
         simd_width: Int, alignment: Int = align_of[dtype]()
@@ -128,7 +128,7 @@ def manual_vectorized_tiled_elementwise_add[
     # Each tile contains tile_size groups of simd_width elements
     comptime chunk_size = tile_size * simd_width
 
-    @__parameter
+    @parameter
     @always_inline
     def process_manual_vectorized_tiles[
         num_threads_per_tile: Int, alignment: Int = align_of[dtype]()
@@ -173,7 +173,7 @@ def vectorize_within_tiles_elementwise_add[
     ctx: DeviceContext,
 ) raises:
     # Each tile contains tile_size elements (not SIMD groups)
-    @__parameter
+    @parameter
     @always_inline
     def process_tile_with_vectorize[
         num_threads_per_tile: Int, alignment: Int = align_of[dtype]()
@@ -189,7 +189,7 @@ def vectorize_within_tiles_elementwise_add[
 
         def vectorized_add[
             width: Int
-        ](i: Int) {imm tile_start, imm a_lt, imm b_lt, mut out_lt}:
+        ](i: Int) {tile_start, a_lt, b_lt, mut out_lt}:
             var global_idx = tile_start + i
             if global_idx + width <= size:
                 var a_vec = a_lt.aligned_load[width](Index(global_idx))
@@ -209,7 +209,7 @@ def vectorize_within_tiles_elementwise_add[
 # ANCHOR_END: vectorize_within_tiles_elementwise_add_solution
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_elementwise_parameterized[
     test_size: Int, tile_size: Int
@@ -239,7 +239,7 @@ def benchmark_elementwise_parameterized[
         out, bench_layout
     )
 
-    @__parameter
+    @parameter
     @always_inline
     def elementwise_workflow(ctx: DeviceContext) raises:
         elementwise_add[BenchLayoutType, dtype, SIMD_WIDTH, rank, test_size](
@@ -251,7 +251,7 @@ def benchmark_elementwise_parameterized[
     bench_ctx.synchronize()
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_tiled_parameterized[
     test_size: Int, tile_size: Int
@@ -281,7 +281,7 @@ def benchmark_tiled_parameterized[
         out, bench_layout
     )
 
-    @__parameter
+    @parameter
     @always_inline
     def tiled_workflow(ctx: DeviceContext) raises:
         tiled_elementwise_add[
@@ -293,7 +293,7 @@ def benchmark_tiled_parameterized[
     bench_ctx.synchronize()
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_manual_vectorized_parameterized[
     test_size: Int, tile_size: Int
@@ -323,7 +323,7 @@ def benchmark_manual_vectorized_parameterized[
         out, bench_layout
     )
 
-    @__parameter
+    @parameter
     @always_inline
     def manual_vectorized_workflow(ctx: DeviceContext) raises:
         manual_vectorized_tiled_elementwise_add[
@@ -335,7 +335,7 @@ def benchmark_manual_vectorized_parameterized[
     bench_ctx.synchronize()
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_vectorized_parameterized[
     test_size: Int, tile_size: Int
@@ -365,7 +365,7 @@ def benchmark_vectorized_parameterized[
         out, bench_layout
     )
 
-    @__parameter
+    @parameter
     @always_inline
     def vectorized_workflow(ctx: DeviceContext) raises:
         vectorize_within_tiles_elementwise_add[

--- a/solutions/p24/p24.mojo
+++ b/solutions/p24/p24.mojo
@@ -137,7 +137,7 @@ def functional_warp_dot_product[
     b: TileTensor[mut=False, dtype, InLayoutT, MutAnyOrigin],
     ctx: DeviceContext,
 ) raises:
-    @__parameter
+    @parameter
     @always_inline
     def compute_dot_product[
         simd_width: Int, alignment: Int = align_of[dtype]()
@@ -211,7 +211,7 @@ def check_result[
             assert_equal(actual_host[i], expected[i])
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_simple_warp_parameterized[
     test_size: Int
@@ -249,7 +249,7 @@ def benchmark_simple_warp_parameterized[
         out, bench_out_layout
     )
 
-    @__parameter
+    @parameter
     @always_inline
     def traditional_workflow(ctx: DeviceContext) raises:
         comptime kernel = simple_warp_dot_product[
@@ -271,7 +271,7 @@ def benchmark_simple_warp_parameterized[
     bench_ctx.synchronize()
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_functional_warp_parameterized[
     test_size: Int
@@ -307,7 +307,7 @@ def benchmark_functional_warp_parameterized[
         TileTensor[mut=True, dtype, BenchOutLayout, MutAnyOrigin]
     ](TileTensor[mut=True, dtype, BenchOutLayout](out, bench_out_layout))
 
-    @__parameter
+    @parameter
     @always_inline
     def functional_warp_workflow(ctx: DeviceContext) raises:
         functional_warp_dot_product[dtype, SIMD_WIDTH, 1, test_size](
@@ -322,7 +322,7 @@ def benchmark_functional_warp_parameterized[
     bench_ctx.synchronize()
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_traditional_parameterized[
     test_size: Int
@@ -359,7 +359,7 @@ def benchmark_traditional_parameterized[
         out, bench_out_layout
     )
 
-    @__parameter
+    @parameter
     @always_inline
     def traditional_workflow(ctx: DeviceContext) raises:
         ctx.enqueue_function[

--- a/solutions/p30/p30.mojo
+++ b/solutions/p30/p30.mojo
@@ -1,0 +1,428 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+from std.gpu import thread_idx, block_dim, block_idx
+from max.gpu.host import DeviceContext
+from layout import TileTensor
+from layout.tile_layout import row_major
+from std.sys import argv
+from std.testing import assert_almost_equal
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId, keep
+from max.benchmark import bencher_iter_custom
+
+comptime SIZE = 16 * 1024 * 1024  # 16M elements - large enough to show memory patterns
+comptime THREADS_PER_BLOCK = (1024, 1)  # Max CUDA threads per block
+comptime BLOCKS_PER_GRID = (
+    SIZE // 1024,
+    1,
+)  # Enough blocks to cover all elements
+comptime dtype = DType.float32
+comptime layout = row_major[SIZE]()
+comptime LayoutType = type_of(layout)
+
+
+# ANCHOR: kernel1
+def kernel1(
+    output: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    a: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    b: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    size_dev: Int32,
+):
+    var size = Int(size_dev)
+    var i = block_dim.x * block_idx.x + thread_idx.x
+    if i < size:
+        output[i] = a[i] + b[i]
+
+
+# ANCHOR_END: kernel1
+
+
+# ANCHOR: kernel2
+def kernel2(
+    output: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    a: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    b: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    size_dev: Int32,
+):
+    var size = Int(size_dev)
+    var tid = block_idx.x * block_dim.x + thread_idx.x
+    var stride = 512
+
+    var i = tid
+    while i < size:
+        output[i] = a[i] + b[i]
+        i += stride
+
+
+# ANCHOR_END: kernel2
+
+
+# ANCHOR: kernel3
+def kernel3(
+    output: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    a: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    b: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    size_dev: Int32,
+):
+    var size = Int(size_dev)
+    var tid = block_idx.x * block_dim.x + thread_idx.x
+    var total_threads = (SIZE // 1024) * 1024
+
+    for step in range(0, size, total_threads):
+        var forward_i = step + tid
+        if forward_i < size:
+            var reverse_i = size - 1 - forward_i
+            output[reverse_i] = a[reverse_i] + b[reverse_i]
+
+
+# ANCHOR_END: kernel3
+
+
+@parameter
+@always_inline
+def benchmark_kernel1_parameterized[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def kernel1_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var out = ctx.enqueue_create_buffer[dtype](test_size)
+        out.enqueue_fill(0)
+        var a = ctx.enqueue_create_buffer[dtype](test_size)
+        a.enqueue_fill(0)
+        var b_buf = ctx.enqueue_create_buffer[dtype](test_size)
+        b_buf.enqueue_fill(0)
+
+        with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
+            for i in range(test_size):
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
+
+        var out_tensor = TileTensor(out, layout)
+        var a_tensor = TileTensor[mut=False, dtype, LayoutType](a, layout)
+        var b_tensor = TileTensor[mut=False, dtype, LayoutType](b_buf, layout)
+
+        ctx.enqueue_function[kernel1](
+            out_tensor,
+            a_tensor,
+            b_tensor,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(out)
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[kernel1_workflow](b, bench_ctx)
+
+
+@parameter
+@always_inline
+def benchmark_kernel2_parameterized[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def kernel2_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var out = ctx.enqueue_create_buffer[dtype](test_size)
+        out.enqueue_fill(0)
+        var a = ctx.enqueue_create_buffer[dtype](test_size)
+        a.enqueue_fill(0)
+        var b_buf = ctx.enqueue_create_buffer[dtype](test_size)
+        b_buf.enqueue_fill(0)
+
+        with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
+            for i in range(test_size):
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
+
+        var out_tensor = TileTensor(out, layout)
+        var a_tensor = TileTensor[mut=False, dtype, LayoutType](a, layout)
+        var b_tensor = TileTensor[mut=False, dtype, LayoutType](b_buf, layout)
+
+        ctx.enqueue_function[kernel2](
+            out_tensor,
+            a_tensor,
+            b_tensor,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(out)
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[kernel2_workflow](b, bench_ctx)
+
+
+@parameter
+@always_inline
+def benchmark_kernel3_parameterized[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def kernel3_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var out = ctx.enqueue_create_buffer[dtype](test_size)
+        out.enqueue_fill(0)
+        var a = ctx.enqueue_create_buffer[dtype](test_size)
+        a.enqueue_fill(0)
+        var b_buf = ctx.enqueue_create_buffer[dtype](test_size)
+        b_buf.enqueue_fill(0)
+
+        with a.map_to_host() as a_host, b_buf.map_to_host() as b_host:
+            for i in range(test_size):
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
+
+        var out_tensor = TileTensor(out, layout)
+        var a_tensor = TileTensor[mut=False, dtype, LayoutType](a, layout)
+        var b_tensor = TileTensor[mut=False, dtype, LayoutType](b_buf, layout)
+
+        ctx.enqueue_function[kernel3](
+            out_tensor,
+            a_tensor,
+            b_tensor,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(out)
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[kernel3_workflow](b, bench_ctx)
+
+
+def test_kernel1() raises:
+    """Test kernel 1."""
+    print("Testing kernel 1...")
+    with DeviceContext() as ctx:
+        var out = ctx.enqueue_create_buffer[dtype](SIZE)
+        out.enqueue_fill(0)
+        var a = ctx.enqueue_create_buffer[dtype](SIZE)
+        a.enqueue_fill(0)
+        var b = ctx.enqueue_create_buffer[dtype](SIZE)
+        b.enqueue_fill(0)
+
+        # Initialize test data
+        with a.map_to_host() as a_host, b.map_to_host() as b_host:
+            for i in range(SIZE):
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
+
+        # Create TileTensors
+        var out_tensor = TileTensor(out, layout)
+        var a_tensor = TileTensor[mut=False, dtype, LayoutType](a, layout)
+        var b_tensor = TileTensor[mut=False, dtype, LayoutType](b, layout)
+
+        ctx.enqueue_function[kernel1](
+            out_tensor,
+            a_tensor,
+            b_tensor,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        ctx.synchronize()
+
+        # Verify results
+        with out.map_to_host() as out_host, a.map_to_host() as a_host, b.map_to_host() as b_host:
+            for i in range(10):  # Check first 10
+                var expected = a_host[i] + b_host[i]
+                var actual = out_host[i]
+                assert_almost_equal(expected, actual)
+
+        print("Kernel 1 test: passed")
+
+
+def test_kernel2() raises:
+    """Test kernel 2."""
+    print("Testing kernel 2...")
+    with DeviceContext() as ctx:
+        var out = ctx.enqueue_create_buffer[dtype](SIZE)
+        out.enqueue_fill(0)
+        var a = ctx.enqueue_create_buffer[dtype](SIZE)
+        a.enqueue_fill(0)
+        var b = ctx.enqueue_create_buffer[dtype](SIZE)
+        b.enqueue_fill(0)
+
+        # Initialize test data
+        with a.map_to_host() as a_host, b.map_to_host() as b_host:
+            for i in range(SIZE):
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
+
+        # Create TileTensors
+        var out_tensor = TileTensor(out, layout)
+        var a_tensor = TileTensor[mut=False, dtype, LayoutType](a, layout)
+        var b_tensor = TileTensor[mut=False, dtype, LayoutType](b, layout)
+
+        ctx.enqueue_function[kernel2](
+            out_tensor,
+            a_tensor,
+            b_tensor,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        ctx.synchronize()
+
+        # Verify results
+        var processed = 0
+        with out.map_to_host() as out_host, a.map_to_host() as a_host, b.map_to_host() as b_host:
+            for i in range(SIZE):
+                if out_host[i] != 0:  # This element was processed
+                    var expected = a_host[i] + b_host[i]
+                    var actual = out_host[i]
+                    assert_almost_equal(expected, actual)
+                    processed += 1
+
+        print("Kernel 2 test: passed")
+
+
+def test_kernel3() raises:
+    """Test kernel 3."""
+    print("Testing kernel 3...")
+    with DeviceContext() as ctx:
+        var out = ctx.enqueue_create_buffer[dtype](SIZE)
+        out.enqueue_fill(0)
+        var a = ctx.enqueue_create_buffer[dtype](SIZE)
+        a.enqueue_fill(0)
+        var b = ctx.enqueue_create_buffer[dtype](SIZE)
+        b.enqueue_fill(0)
+
+        # Initialize test data
+        with a.map_to_host() as a_host, b.map_to_host() as b_host:
+            for i in range(SIZE):
+                a_host[i] = Scalar[dtype](i + 1)
+                b_host[i] = Scalar[dtype](i + 2)
+
+        # Create TileTensors
+        var out_tensor = TileTensor(out, layout)
+        var a_tensor = TileTensor[mut=False, dtype, LayoutType](a, layout)
+        var b_tensor = TileTensor[mut=False, dtype, LayoutType](b, layout)
+
+        ctx.enqueue_function[kernel3](
+            out_tensor,
+            a_tensor,
+            b_tensor,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        ctx.synchronize()
+
+        # Verify results
+        with out.map_to_host() as out_host, a.map_to_host() as a_host, b.map_to_host() as b_host:
+            for i in range(SIZE):
+                var expected = a_host[i] + b_host[i]
+                var actual = out_host[i]
+                assert_almost_equal(expected, actual)
+
+        print("Kernel 3 test: passed")
+
+
+def main() raises:
+    """Run the memory access pattern tests."""
+    var args = argv()
+    if len(args) < 2:
+        print("Usage: mojo p30.mojo <flags>")
+        print("  Flags:")
+        print("    --kernel1     Test kernel 1")
+        print("    --kernel2     Test kernel 2")
+        print("    --kernel3     Test kernel 3")
+        print("    --all         Test all kernels")
+        print("    --benchmark   Run benchmarks for all kernels")
+        return
+
+    # Parse flags
+    var run_kernel1 = False
+    var run_kernel2 = False
+    var run_kernel3 = False
+    var run_all = False
+    var run_benchmark = False
+
+    for i in range(1, len(args)):
+        var arg = args[i]
+        if arg == "--kernel1":
+            run_kernel1 = True
+        elif arg == "--kernel2":
+            run_kernel2 = True
+        elif arg == "--kernel3":
+            run_kernel3 = True
+        elif arg == "--all":
+            run_all = True
+        elif arg == "--benchmark":
+            run_benchmark = True
+        else:
+            print("Unknown flag:", arg)
+            print(
+                "Valid flags: --kernel1, --kernel2, --kernel3, --all,"
+                " --benchmark"
+            )
+            return
+
+    print("MEMORY ACCESS PATTERN MYSTERY")
+    print("================================")
+    print("Vector size:", SIZE, "elements")
+    print(
+        "Grid config:",
+        BLOCKS_PER_GRID[0],
+        "blocks x",
+        THREADS_PER_BLOCK[0],
+        "threads",
+    )
+
+    if run_all:
+        print("\nTesting all kernels...")
+        test_kernel1()
+        test_kernel2()
+        test_kernel3()
+        print("Puzzle 30 complete ✅")
+
+    elif run_benchmark:
+        print("\nRunning Kernel Performance Benchmarks...")
+        print("Use nsys/ncu to profile these for detailed analysis!")
+        print("-" * 50)
+
+        var bench = Bench()
+
+        print("Benchmarking Kernel 1")
+        bench.bench_function[benchmark_kernel1_parameterized[SIZE]](
+            BenchId("kernel1")
+        )
+
+        print("Benchmarking Kernel 2")
+        bench.bench_function[benchmark_kernel2_parameterized[SIZE]](
+            BenchId("kernel2")
+        )
+
+        print("Benchmarking Kernel 3")
+        bench.bench_function[benchmark_kernel3_parameterized[SIZE]](
+            BenchId("kernel3")
+        )
+
+        bench.dump_report()
+    else:
+        # Run individual tests
+        if run_kernel1:
+            test_kernel1()
+        if run_kernel2:
+            test_kernel2()
+        if run_kernel3:
+            test_kernel3()
+        print("Puzzle 30 complete ✅")

--- a/solutions/p31/p31.mojo
+++ b/solutions/p31/p31.mojo
@@ -1,0 +1,530 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+from std.gpu import thread_idx, block_dim, block_idx
+from max.gpu.sync import barrier
+from max.gpu.host import DeviceContext
+from layout import TileTensor
+from layout.tile_layout import row_major
+from layout.tile_tensor import stack_allocation
+from std.sys import argv
+from std.testing import assert_almost_equal
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId, keep
+from max.benchmark import bencher_iter_custom
+
+# ANCHOR: minimal_kernel
+comptime SIZE = 32 * 1024 * 1024  # 32M elements - larger workload to show occupancy effects
+comptime THREADS_PER_BLOCK = (1024, 1)
+comptime BLOCKS_PER_GRID = (SIZE // 1024, 1)
+comptime dtype = DType.float32
+comptime layout = row_major[SIZE]()
+comptime LayoutType = type_of(layout)
+comptime ALPHA = Scalar[dtype](2.5)  # SAXPY coefficient
+
+
+def minimal_kernel(
+    y: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    x: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    alpha: Float32,
+    size_dev: Int32,
+):
+    """Minimal SAXPY kernel - simple and register-light for high occupancy."""
+    var size = Int(size_dev)
+    var i = block_dim.x * block_idx.x + thread_idx.x
+    if i < size:
+        # Direct computation: y[i] = alpha * x[i] + y[i]
+        # Uses minimal registers (~8), no shared memory
+        y[i] = alpha * x[i] + y[i]
+
+
+# ANCHOR_END: minimal_kernel
+
+
+# ANCHOR: sophisticated_kernel
+def sophisticated_kernel(
+    y: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    x: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    alpha: Float32,
+    size_dev: Int32,
+):
+    """Sophisticated SAXPY kernel - over-engineered with excessive resource usage.
+    """
+    var size = Int(size_dev)
+    # Maximum shared memory allocation (close to 48KB limit)
+    var shared_cache = stack_allocation[
+        dtype=dtype, address_space=AddressSpace.SHARED
+    ](
+        row_major[1024 * 12]()
+    )  # 48KB
+
+    var i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
+
+    if i < size:
+        # REAL computational work that can't be optimized away - affects final result
+        var base_x = x[i]
+        var base_y = y[i]
+
+        # Simulate "precision enhancement" - multiple small adjustments that add up
+        # Each computation affects the final result so compiler can't eliminate them
+        # But artificially increases register pressure
+        var precision_x1 = base_x * 1.0001
+        var precision_x2 = precision_x1 * 0.9999
+        var precision_x3 = precision_x2 * 1.000001
+        var precision_x4 = precision_x3 * 0.999999
+
+        var precision_y1 = base_y * 1.000005
+        var precision_y2 = precision_y1 * 0.999995
+        var precision_y3 = precision_y2 * 1.0000001
+        var precision_y4 = precision_y3 * 0.9999999
+
+        # Multiple alpha computations for "stability" - should equal alpha
+        var alpha1 = alpha * 1.00001 * 0.99999
+        var alpha2 = alpha1 * 1.000001 * 0.999999
+        var alpha3 = alpha2 * 1.0000001 * 0.9999999
+        var alpha4 = alpha3 * 1.00000001 * 0.99999999
+
+        # Complex polynomial "optimization" - creates register pressure
+        var x_power2 = precision_x4 * precision_x4
+        var x_power3 = x_power2 * precision_x4
+        var x_power4 = x_power3 * precision_x4
+        var x_power5 = x_power4 * precision_x4
+        var x_power6 = x_power5 * precision_x4
+        var x_power7 = x_power6 * precision_x4
+        var x_power8 = x_power7 * precision_x4
+
+        # "Advanced" mathematical series that contributes tiny amount to result
+        var series_term1 = x_power2 * 0.0000001  # x^2/10M
+        var series_term2 = x_power4 * 0.00000001  # x^4/100M
+        var series_term3 = x_power6 * 0.000000001  # x^6/1B
+        var series_term4 = x_power8 * 0.0000000001  # x^8/10B
+        var series_correction = (
+            series_term1 - series_term2 + series_term3 - series_term4
+        )
+
+        # Over-engineered shared memory usage with multiple caching strategies
+        if local_i < 1024:
+            shared_cache[local_i] = precision_x4
+            shared_cache[local_i + 1024] = precision_y4
+            shared_cache[local_i + 2048] = alpha4
+            shared_cache[local_i + 3072] = series_correction
+        barrier()
+
+        # Load from shared memory for "optimization"
+        var cached_x = shared_cache[local_i] if local_i < 1024 else precision_x4
+        var cached_y = (
+            shared_cache[local_i + 1024] if local_i < 1024 else precision_y4
+        )
+        var cached_alpha = (
+            shared_cache[local_i + 2048] if local_i < 1024 else alpha4
+        )
+        var cached_correction = (
+            shared_cache[local_i + 3072] if local_i
+            < 1024 else series_correction
+        )
+
+        # Final "high precision" computation - all work contributes to result
+        var high_precision_result = (
+            cached_alpha * cached_x + cached_y + cached_correction
+        )
+
+        # Over-engineered result with massive resource usage but mathematically ~= alpha*x + y
+        y[i] = high_precision_result
+
+
+# ANCHOR_END: sophisticated_kernel
+
+
+# ANCHOR: balanced_kernel
+def balanced_kernel(
+    y: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    x: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    alpha: Float32,
+    size_dev: Int32,
+):
+    """Balanced SAXPY kernel - efficient optimization with moderate resources.
+    """
+    var size = Int(size_dev)
+    # Reasonable shared memory usage for effective caching (16KB)
+    var shared_cache = stack_allocation[
+        dtype=dtype, address_space=AddressSpace.SHARED
+    ](
+        row_major[1024 * 4]()
+    )  # 16KB total
+
+    var i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
+
+    if i < size:
+        # Moderate computational work that contributes to result
+        var base_x = x[i]
+        var base_y = y[i]
+
+        # Light precision enhancement - less than sophisticated kernel
+        var enhanced_x = base_x * 1.00001 * 0.99999
+        var enhanced_y = base_y * 1.00001 * 0.99999
+        var stable_alpha = alpha * 1.000001 * 0.999999
+
+        # Moderate computational optimization
+        var x_squared = enhanced_x * enhanced_x
+        var optimization_hint = x_squared * 0.000001
+
+        # Efficient shared memory caching - only what we actually need
+        if local_i < 1024:
+            shared_cache[local_i] = enhanced_x
+            shared_cache[local_i + 1024] = enhanced_y
+        barrier()
+
+        # Use cached values efficiently
+        var cached_x = shared_cache[local_i] if local_i < 1024 else enhanced_x
+        var cached_y = (
+            shared_cache[local_i + 1024] if local_i < 1024 else enhanced_y
+        )
+
+        # Balanced computation - moderate work, good efficiency
+        var result = stable_alpha * cached_x + cached_y + optimization_hint
+
+        # Balanced result with moderate resource usage (~15 registers, 16KB shared)
+        y[i] = result
+
+
+# ANCHOR_END: balanced_kernel
+
+
+@parameter
+@always_inline
+def benchmark_minimal_parameterized[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def minimal_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var y = ctx.enqueue_create_buffer[dtype](test_size)
+        y.enqueue_fill(0)
+        var x = ctx.enqueue_create_buffer[dtype](test_size)
+        x.enqueue_fill(0)
+
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(test_size):
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
+
+        var y_tensor = TileTensor(y, layout)
+        var x_tensor = TileTensor[mut=False, dtype, LayoutType](x, layout)
+
+        comptime kernel = minimal_kernel
+        ctx.enqueue_function[kernel](
+            y_tensor,
+            x_tensor,
+            ALPHA,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(y.unsafe_ptr())
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[minimal_workflow](b, bench_ctx)
+
+
+@parameter
+@always_inline
+def benchmark_sophisticated_parameterized[
+    test_size: Int
+](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def sophisticated_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var y = ctx.enqueue_create_buffer[dtype](test_size)
+        y.enqueue_fill(0)
+        var x = ctx.enqueue_create_buffer[dtype](test_size)
+        x.enqueue_fill(0)
+
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(test_size):
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
+
+        var y_tensor = TileTensor(y, layout)
+        var x_tensor = TileTensor[mut=False, dtype, LayoutType](x, layout)
+
+        comptime kernel = sophisticated_kernel
+        ctx.enqueue_function[kernel](
+            y_tensor,
+            x_tensor,
+            ALPHA,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(y.unsafe_ptr())
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[sophisticated_workflow](b, bench_ctx)
+
+
+@parameter
+@always_inline
+def benchmark_balanced_parameterized[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def balanced_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var y = ctx.enqueue_create_buffer[dtype](test_size)
+        y.enqueue_fill(0)
+        var x = ctx.enqueue_create_buffer[dtype](test_size)
+        x.enqueue_fill(0)
+
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(test_size):
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
+
+        var y_tensor = TileTensor(y, layout)
+        var x_tensor = TileTensor[mut=False, dtype, LayoutType](x, layout)
+
+        comptime kernel = balanced_kernel
+        ctx.enqueue_function[kernel](
+            y_tensor,
+            x_tensor,
+            ALPHA,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(y.unsafe_ptr())
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[balanced_workflow](b, bench_ctx)
+
+
+def test_minimal() raises:
+    """Test minimal kernel."""
+    print("Testing minimal kernel...")
+    with DeviceContext() as ctx:
+        var y = ctx.enqueue_create_buffer[dtype](SIZE)
+        y.enqueue_fill(0)
+        var x = ctx.enqueue_create_buffer[dtype](SIZE)
+        x.enqueue_fill(0)
+
+        # Initialize test data
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(SIZE):
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
+
+        # Create TileTensors
+        var y_tensor = TileTensor(y, layout)
+        var x_tensor = TileTensor[mut=False, dtype, LayoutType](x, layout)
+
+        comptime kernel = minimal_kernel
+        ctx.enqueue_function[kernel](
+            y_tensor,
+            x_tensor,
+            ALPHA,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        ctx.synchronize()
+
+        # Verify results: y[i] = alpha * x[i] + original_y[i]
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(10):  # Check first 10
+                var expected = ALPHA * x_host[i] + Scalar[dtype](
+                    i + 2
+                )  # original y[i] was (i + 2)
+                var actual = y_host[i]
+                assert_almost_equal(expected, actual)
+
+        print("Minimal kernel test: passed")
+
+
+def test_sophisticated() raises:
+    """Test sophisticated kernel."""
+    print("Testing sophisticated kernel...")
+    with DeviceContext() as ctx:
+        var y = ctx.enqueue_create_buffer[dtype](SIZE)
+        y.enqueue_fill(0)
+        var x = ctx.enqueue_create_buffer[dtype](SIZE)
+        x.enqueue_fill(0)
+
+        # Initialize test data
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(SIZE):
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
+
+        # Create TileTensors
+        var y_tensor = TileTensor(y, layout)
+        var x_tensor = TileTensor[mut=False, dtype, LayoutType](x, layout)
+
+        comptime kernel = sophisticated_kernel
+        ctx.enqueue_function[kernel](
+            y_tensor,
+            x_tensor,
+            ALPHA,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        ctx.synchronize()
+
+        # Verify results: y[i] = alpha * x[i] + original_y[i] (with precision tolerance)
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(10):  # Check first 10
+                var expected = ALPHA * x_host[i] + Scalar[dtype](
+                    i + 2
+                )  # original y[i] was (i + 2)
+                var actual = y_host[i]
+                # Higher tolerance for sophisticated kernel's precision enhancements
+                assert_almost_equal(expected, actual, rtol=1e-3, atol=1e-3)
+
+        print("Sophisticated kernel test: passed")
+
+
+def test_balanced() raises:
+    """Test balanced kernel."""
+    print("Testing balanced kernel...")
+    with DeviceContext() as ctx:
+        var y = ctx.enqueue_create_buffer[dtype](SIZE)
+        y.enqueue_fill(0)
+        var x = ctx.enqueue_create_buffer[dtype](SIZE)
+        x.enqueue_fill(0)
+
+        # Initialize test data
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(SIZE):
+                x_host[i] = Scalar[dtype](i + 1)
+                y_host[i] = Scalar[dtype](i + 2)
+
+        # Create TileTensors
+        var y_tensor = TileTensor(y, layout)
+        var x_tensor = TileTensor[mut=False, dtype, LayoutType](x, layout)
+
+        comptime kernel = balanced_kernel
+        ctx.enqueue_function[kernel](
+            y_tensor,
+            x_tensor,
+            ALPHA,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        ctx.synchronize()
+
+        # Verify results: y[i] = alpha * x[i] + original_y[i] (with precision tolerance)
+        with y.map_to_host() as y_host, x.map_to_host() as x_host:
+            for i in range(10):  # Check first 10
+                var expected = ALPHA * x_host[i] + Scalar[dtype](
+                    i + 2
+                )  # original y[i] was (i + 2)
+                var actual = y_host[i]
+                # Higher tolerance for balanced kernel's precision enhancements
+                assert_almost_equal(expected, actual, rtol=1e-4, atol=1e-4)
+
+        print("Balanced kernel test: passed")
+
+
+def main() raises:
+    """Run the occupancy efficiency mystery tests."""
+    var args = argv()
+    if len(args) < 2:
+        print("Usage: mojo p31.mojo <flags>")
+        print("  Flags:")
+        print("    --minimal       Test minimal kernel (high occupancy)")
+        print("    --sophisticated Test sophisticated kernel (low occupancy)")
+        print("    --balanced      Test balanced kernel (optimal occupancy)")
+        print("    --all           Test all kernels")
+        print("    --benchmark     Run benchmarks for all kernels")
+        return
+
+    # Parse flags
+    var run_minimal = False
+    var run_sophisticated = False
+    var run_balanced = False
+    var run_all = False
+    var run_benchmark = False
+
+    for i in range(1, len(args)):
+        var arg = args[i]
+        if arg == "--minimal":
+            run_minimal = True
+        elif arg == "--sophisticated":
+            run_sophisticated = True
+        elif arg == "--balanced":
+            run_balanced = True
+        elif arg == "--all":
+            run_all = True
+        elif arg == "--benchmark":
+            run_benchmark = True
+        else:
+            print("Unknown flag:", arg)
+            print(
+                "Valid flags: --minimal, --sophisticated, --balanced, --all,"
+                " --benchmark"
+            )
+            return
+
+    print("============================")
+    print("Vector size:", SIZE, "elements (32M - large workload)")
+    print("Operation: SAXPY y[i] = alpha * x[i] + y[i], alpha =", ALPHA)
+    print(
+        "Grid config:",
+        BLOCKS_PER_GRID[0],
+        "blocks x",
+        THREADS_PER_BLOCK[0],
+        "threads",
+    )
+
+    if run_all:
+        print("\nTesting all kernels...")
+        test_minimal()
+        test_sophisticated()
+        test_balanced()
+        print("Puzzle 31 complete ✅")
+
+    elif run_benchmark:
+        var bench = Bench()
+        print("Benchmarking Minimal Kernel (High Occupancy)")
+        bench.bench_function[benchmark_minimal_parameterized[SIZE]](
+            BenchId("minimal")
+        )
+
+        print("Benchmarking Sophisticated Kernel (Low Occupancy)")
+        bench.bench_function[benchmark_sophisticated_parameterized[SIZE]](
+            BenchId("sophisticated")
+        )
+
+        print("Benchmarking Balanced Kernel (Optimal Occupancy)")
+        bench.bench_function[benchmark_balanced_parameterized[SIZE]](
+            BenchId("balanced")
+        )
+
+        bench.dump_report()
+    else:
+        if run_minimal:
+            test_minimal()
+        if run_sophisticated:
+            test_sophisticated()
+        if run_balanced:
+            test_balanced()
+        print("Puzzle 31 complete ✅")

--- a/solutions/p32/p32.mojo
+++ b/solutions/p32/p32.mojo
@@ -1,0 +1,304 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+from std.gpu import thread_idx, block_dim, block_idx
+from max.gpu.sync import barrier
+from max.gpu.host import DeviceContext
+from layout import TileTensor
+from layout.tile_layout import row_major
+from layout.tile_tensor import stack_allocation
+from std.sys import argv
+from std.testing import assert_almost_equal
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId, keep
+from max.benchmark import bencher_iter_custom
+
+# ANCHOR: no_conflict_kernel
+comptime SIZE = 8 * 1024  # 8K elements - small enough to focus on shared memory patterns
+comptime TPB = 256  # Threads per block - divisible by 32 (warp size)
+comptime THREADS_PER_BLOCK = (TPB, 1)
+comptime BLOCKS_PER_GRID = (SIZE // TPB, 1)
+comptime dtype = DType.float32
+comptime layout = row_major[SIZE]()
+comptime LayoutType = type_of(layout)
+
+
+def no_conflict_kernel(
+    output: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    input: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    size_dev: Int32,
+):
+    """Perfect shared memory access - no bank conflicts.
+
+    Each thread accesses a different bank: thread_idx.x maps to bank thread_idx.x % 32.
+    This achieves optimal shared memory bandwidth utilization.
+    """
+    var size = Int(size_dev)
+
+    # Shared memory buffer - each thread loads one element
+    var shared_buf = stack_allocation[
+        dtype=dtype, address_space=AddressSpace.SHARED
+    ](row_major[TPB]())
+
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
+
+    # Load from global memory to shared memory - no conflicts
+    if global_i < size:
+        shared_buf[local_i] = (
+            input[global_i] + 10.0
+        )  # Add 10 as simple operation
+
+    barrier()  # Synchronize shared memory writes
+
+    # Read back from shared memory and write to output - no conflicts
+    if global_i < size:
+        output[global_i] = shared_buf[local_i] * 2.0  # Multiply by 2
+
+    barrier()  # Ensure completion
+
+
+# ANCHOR_END: no_conflict_kernel
+
+
+# ANCHOR: two_way_conflict_kernel
+def two_way_conflict_kernel(
+    output: TileTensor[mut=True, dtype, LayoutType, MutAnyOrigin],
+    input: TileTensor[mut=False, dtype, LayoutType, ImmutAnyOrigin],
+    size_dev: Int32,
+):
+    """Stride-2 shared memory access - creates 2-way bank conflicts.
+
+    Threads 0,16 -> Bank 0, Threads 1,17 -> Bank 1, etc.
+    Each bank serves 2 threads, doubling access time.
+    """
+    var size = Int(size_dev)
+
+    # Sized to 2*TPB so stride-2 writes don't alias (threads i and i+TPB/2).
+    var shared_buf = stack_allocation[
+        dtype=dtype, address_space=AddressSpace.SHARED
+    ](row_major[2 * TPB]())
+
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var local_i = thread_idx.x
+
+    # CONFLICT: stride-2 access creates 2-way bank conflicts
+    var conflict_index = local_i * 2
+
+    # Load with bank conflicts
+    if global_i < size:
+        shared_buf[conflict_index] = (
+            input[global_i] + 10.0
+        )  # Same operation as no-conflict
+
+    barrier()  # Synchronize shared memory writes
+
+    # Read back with same conflicts
+    if global_i < size:
+        output[global_i] = (
+            shared_buf[conflict_index] * 2.0
+        )  # Same operation as no-conflict
+
+    barrier()  # Ensure completion
+
+
+# ANCHOR_END: two_way_conflict_kernel
+
+
+@parameter
+@always_inline
+def benchmark_no_conflict[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def kernel_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var out = ctx.enqueue_create_buffer[dtype](test_size)
+        out.enqueue_fill(0)
+        var input_buf = ctx.enqueue_create_buffer[dtype](test_size)
+        input_buf.enqueue_fill(0)
+
+        with input_buf.map_to_host() as input_host:
+            for i in range(test_size):
+                input_host[i] = Scalar[dtype](i + 1)
+
+        var out_tensor = TileTensor(out, layout)
+        var input_tensor = TileTensor[mut=False, dtype, LayoutType](
+            input_buf, layout
+        )
+
+        comptime kernel = no_conflict_kernel
+        ctx.enqueue_function[kernel](
+            out_tensor,
+            input_tensor,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(out.unsafe_ptr())
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[kernel_workflow](b, bench_ctx)
+
+
+@parameter
+@always_inline
+def benchmark_two_way_conflict[test_size: Int](mut b: Bencher) raises:
+    @parameter
+    @always_inline
+    def kernel_workflow(ctx: DeviceContext) raises:
+        comptime layout = row_major[test_size]()
+        comptime LayoutType = type_of(layout)
+        var out = ctx.enqueue_create_buffer[dtype](test_size)
+        out.enqueue_fill(0)
+        var input_buf = ctx.enqueue_create_buffer[dtype](test_size)
+        input_buf.enqueue_fill(0)
+
+        with input_buf.map_to_host() as input_host:
+            for i in range(test_size):
+                input_host[i] = Scalar[dtype](i + 1)
+
+        var out_tensor = TileTensor(out, layout)
+        var input_tensor = TileTensor[mut=False, dtype, LayoutType](
+            input_buf, layout
+        )
+
+        comptime kernel = two_way_conflict_kernel
+        ctx.enqueue_function[kernel](
+            out_tensor,
+            input_tensor,
+            Int32(test_size),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+        keep(out.unsafe_ptr())
+        ctx.synchronize()
+
+    var bench_ctx = DeviceContext()
+    bencher_iter_custom[kernel_workflow](b, bench_ctx)
+
+
+def test_no_conflict() raises:
+    """Test that no-conflict kernel produces correct results."""
+    with DeviceContext() as ctx:
+        var out = ctx.enqueue_create_buffer[dtype](SIZE)
+        out.enqueue_fill(0)
+        var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+        input_buf.enqueue_fill(0)
+
+        with input_buf.map_to_host() as input_host:
+            for i in range(SIZE):
+                input_host[i] = Scalar[dtype](i + 1)
+
+        var out_tensor = TileTensor(out, layout)
+        var input_tensor = TileTensor[mut=False, dtype, LayoutType](
+            input_buf, layout
+        )
+
+        comptime kernel = no_conflict_kernel
+        ctx.enqueue_function[kernel](
+            out_tensor,
+            input_tensor,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        with out.map_to_host() as result:
+            for i in range(min(SIZE, 10)):
+                var expected = Scalar[dtype]((i + 11) * 2)
+                assert_almost_equal(result[i], expected, atol=1e-5)
+
+        print("No-conflict kernel test: passed")
+
+
+def test_two_way_conflict() raises:
+    """Test that 2-way conflict kernel produces identical results."""
+    with DeviceContext() as ctx:
+        var out = ctx.enqueue_create_buffer[dtype](SIZE)
+        out.enqueue_fill(0)
+        var input_buf = ctx.enqueue_create_buffer[dtype](SIZE)
+        input_buf.enqueue_fill(0)
+
+        with input_buf.map_to_host() as input_host:
+            for i in range(SIZE):
+                input_host[i] = Scalar[dtype](i + 1)
+
+        var out_tensor = TileTensor(out, layout)
+        var input_tensor = TileTensor[mut=False, dtype, LayoutType](
+            input_buf, layout
+        )
+
+        comptime kernel = two_way_conflict_kernel
+        ctx.enqueue_function[kernel](
+            out_tensor,
+            input_tensor,
+            Int32(SIZE),
+            grid_dim=BLOCKS_PER_GRID,
+            block_dim=THREADS_PER_BLOCK,
+        )
+
+        with out.map_to_host() as result:
+            for i in range(min(SIZE, 10)):
+                var expected = Scalar[dtype]((i + 11) * 2)
+                assert_almost_equal(result[i], expected, atol=1e-5)
+
+        print("Two-way conflict kernel test: passed")
+
+
+def main() raises:
+    if len(argv()) < 2:
+        print(
+            "Usage: mojo p32.mojo [--test] [--benchmark] [--no-conflict]"
+            " [--two-way]"
+        )
+        return
+
+    var arg = argv()[1]
+
+    if arg == "--test":
+        print("Testing bank conflict kernels...")
+        test_no_conflict()
+        test_two_way_conflict()
+        print("Puzzle 32 complete ✅")
+        print("Now profile with NSight Compute to see performance differences!")
+
+    elif arg == "--benchmark":
+        print("Benchmarking bank conflict patterns...")
+        print("-" * 50)
+
+        var bench = Bench()
+
+        print("\nNo-conflict kernel (optimal):")
+        bench.bench_function[benchmark_no_conflict[SIZE]](
+            BenchId("no_conflict")
+        )
+
+        print("\nTwo-way conflict kernel:")
+        bench.bench_function[benchmark_two_way_conflict[SIZE]](
+            BenchId("two_way_conflict")
+        )
+
+        bench.dump_report()
+
+    elif arg == "--no-conflict":
+        test_no_conflict()
+        print("Puzzle 32 complete ✅")
+    elif arg == "--two-way":
+        test_two_way_conflict()
+        print("Puzzle 32 complete ✅")
+    else:
+        print("Unknown argument:", arg)
+        print(
+            "Usage: mojo p32.mojo [--test] [--benchmark] [--no-conflict]"
+            " [--two-way]"
+        )

--- a/solutions/p35/p35.mojo
+++ b/solutions/p35/p35.mojo
@@ -237,10 +237,10 @@ def test_aligned() raises:
 # ---------------------------------------------------------------------------- #
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_scalar(mut b: Bencher) raises:
-    @__parameter
+    @parameter
     @always_inline
     def workflow(ctx: DeviceContext) raises:
         var out = ctx.enqueue_create_buffer[dtype](SIZE)
@@ -267,10 +267,10 @@ def benchmark_scalar(mut b: Bencher) raises:
     bencher_iter_custom[workflow](b, bench_ctx)
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_unaligned(mut b: Bencher) raises:
-    @__parameter
+    @parameter
     @always_inline
     def workflow(ctx: DeviceContext) raises:
         var out = ctx.enqueue_create_buffer[dtype](SIZE)
@@ -297,10 +297,10 @@ def benchmark_unaligned(mut b: Bencher) raises:
     bencher_iter_custom[workflow](b, bench_ctx)
 
 
-@__parameter
+@parameter
 @always_inline
 def benchmark_aligned(mut b: Bencher) raises:
-    @__parameter
+    @parameter
     @always_inline
     def workflow(ctx: DeviceContext) raises:
         var out = ctx.enqueue_create_buffer[dtype](SIZE)

--- a/solutions/run.sh
+++ b/solutions/run.sh
@@ -15,6 +15,26 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 
+# Prefer the repo's own virtualenv when present (pixi-less setups); fall
+# back to whatever `python` resolves to on PATH (pixi shell, CI).
+if [ -x "${SCRIPT_DIR}/../.venv/bin/python" ]; then
+    PYTHON_BIN="${SCRIPT_DIR}/../.venv/bin/python"
+else
+    PYTHON_BIN="python"
+fi
+
+# TheRock rocm-sdk runtime libs (when installed into the venv): put them on
+# the loader path so torch's preloads and the MAX runtime resolve the same
+# HIP/HSA pair (mixing with the system 7.2.x stack breaks device init).
+# libnuma.so + unversioned libamdhip64.so/libhsa-runtime64.so symlinks and
+# the librocprofiler-register stub are installed in the sdk lib dir.
+VENV_SITE="$(ls -d ${SCRIPT_DIR}/../.venv/lib/python3.*/site-packages 2>/dev/null | head -1)"
+ROCM_SDK_CORE="${VENV_SITE}/_rocm_sdk_core/lib"
+ROCM_SDK_LIBS="${VENV_SITE}/_rocm_sdk_libraries/lib"
+if [ -d "${ROCM_SDK_CORE}" ]; then
+    export LD_LIBRARY_PATH="${ROCM_SDK_CORE}:${ROCM_SDK_LIBS}:${LD_LIBRARY_PATH}"
+fi
+
 # Unicode symbols
 CHECK_MARK="✓"
 CROSS_MARK="✗"
@@ -388,7 +408,7 @@ run_python_files() {
       if [ -n "$specific_flag" ]; then
         # Check if the file supports this flag
         if grep -q "sys\.argv\[1\] == \"$specific_flag\"" "$f"; then
-          execute_or_skip_test "${path_prefix}$f" "$specific_flag" "python \"$f\" \"$specific_flag\""
+          execute_or_skip_test "${path_prefix}$f" "$specific_flag" "$PYTHON_BIN \"$f\" \"$specific_flag\""
         else
           print_test_result "${path_prefix}$f" "$specific_flag" "SKIP"
         fi
@@ -398,10 +418,10 @@ run_python_files() {
         flags=$(grep -oE 'sys\.argv\[1\] == "--[^"]*"|"--[a-z-]+"' "$f" | grep -oE -- '--[a-z-]+' | sort -u | grep -v '^--demo')
 
         if [ -z "$flags" ]; then
-          execute_or_skip_test "${path_prefix}$f" "" "python \"$f\""
+          execute_or_skip_test "${path_prefix}$f" "" "$PYTHON_BIN \"$f\""
         else
           for flag in $flags; do
-            execute_or_skip_test "${path_prefix}$f" "$flag" "python \"$f\" \"$flag\""
+            execute_or_skip_test "${path_prefix}$f" "$flag" "$PYTHON_BIN \"$f\" \"$flag\""
           done
         fi
       fi


### PR DESCRIPTION
## Summary

Completes the four puzzles that had no solutions (p09, p30, p31, p32), ports three existing solutions so they compile on stable Mojo as well as nightly, and fixes several toolchain-agnostic infra issues found while running the suite on an AMD RDNA4 (RX 9070 XT) machine.

## New solutions

- **p09** (crash debugging): fixed all three cases — zero-size input buffer OOB read, `ITER=2` sliding-window bug missing the right neighbour, and a `barrier()` inside a divergent branch causing deadlock. Verified with `--all`.
- **p30** (cache-hit paradox): benchmarked on AMD — kernel2 (stride-512 loop) is **78× slower** (1059 ms vs 13.6 ms @ 16M elements) despite per-warp coalescing, confirming the DRAM row-locality analysis.
- **p31** (occupancy): all three SAXPY kernels measure identically on this card — the workload is DRAM-bound, and the harness's host-side fills dominate wall time for fast kernels.
- **p32** (bank conflicts): 2-way conflict kernel shows no slowdown at 8K or 4M elements — shared traffic hides under global-memory binding; the book's expectations apply to shared-bound kernels only.

## Solution ports (stable-Mojo compat)

`solutions/p23/p23.mojo`, `p24/p24.mojo`, `p35/p35.mojo`: `@__parameter` → `@parameter` (works on both nightly and stable 1.0.0; nightly emits only a deprecation warning).

## Infra fixes

- `solutions/run.sh`: prefer the repo `.venv`'s python when present (`python` only exists inside the pixi shell); export the rocm-sdk lib dir on `LD_LIBRARY_PATH` when installed so torch preloads and the MAX runtime resolve one consistent HIP/HSA pair.
- `scripts/gpu_specs.py`: fall back to `/opt/rocm/bin/rocm-smi` when it isn't on PATH (fixed platform detection on stock Ubuntu ROCm installs).
- `scripts/setup_rocm_sdk_fixes.sh` (new): idempotent workarounds for TheRock rocm-sdk wheel issues — no-op stub for the broken `librocprofiler-register.so.0`, unversioned `libamdhip64.so`/`libhsa-runtime64.so`/`libnuma.so` symlinks, `sitecustomize.py` preload. Documented; only runs on machines that install the sdk wheels into the venv.
- `book/book.toml` + `book/i18n/ko/book.toml`: invoke the youtube/i18n-status preprocessors with `python3` (mdbook builds on stock Linux installs).

## Out of scope (deliberately not in this PR)

- `problems/` skeletons: filled-in verification copies and stable ports are machine-local; upstream targets nightly where `@__parameter` is canonical.
- `pyproject.toml`/`uv.lock`: local pins to the TheRock 7.14 nightly torch stack (torch 2.14.0a0 + `amd-torch-device-gfx1201` kpack package); the rocm6.3-index wheels are broken on RDNA4, but this is environment-specific.

## Validation

Full suite on RX 9070 XT (Mojo 1.0.0 stable, torch/rocm-sdk 7.14 nightly in venv): **56 passed, 0 failed, 14 skipped** (AMD-unsupported puzzles).